### PR TITLE
splitting high-level ugfx driver from low-level input drivers

### DIFF
--- a/components/badge/badge.c
+++ b/components/badge/badge.c
@@ -37,8 +37,7 @@ touch_event_handler(int event)
 			int id = conv[(event >> 8) & 0xff];
 			if (id != -1)
 			{
-				uint32_t button_down = id;
-				xQueueSend(badge_input_queue, &button_down, 0);
+				badge_input_add_event(id, true, false);
 			}
 		}
 	}
@@ -49,8 +48,7 @@ touch_event_handler(int event)
 void
 mpr121_event_handler(void *b)
 {
-	uint32_t button_down = (int) b;
-	xQueueSend(badge_input_queue, &button_down, 0);
+	badge_input_add_event((uint32_t) b, true, false);
 }
 #endif // I2C_MPR121_ADDR
 

--- a/components/badge/badge.c
+++ b/components/badge/badge.c
@@ -37,7 +37,7 @@ touch_event_handler(int event)
 			int id = conv[(event >> 8) & 0xff];
 			if (id != -1)
 			{
-				badge_input_add_event(id, true, false);
+				badge_input_add_event(id, BUTTON_PRESSED, NOT_IN_ISR);
 			}
 		}
 	}
@@ -48,7 +48,7 @@ touch_event_handler(int event)
 void
 mpr121_event_handler(void *b)
 {
-	badge_input_add_event((uint32_t) b, true, false);
+	badge_input_add_event((uint32_t) b, BUTTON_PRESSED, NOT_IN_ISR);
 }
 #endif // I2C_MPR121_ADDR
 

--- a/components/badge/badge.c
+++ b/components/badge/badge.c
@@ -37,7 +37,7 @@ touch_event_handler(int event)
 			int id = conv[(event >> 8) & 0xff];
 			if (id != -1)
 			{
-				badge_input_add_event(id, BUTTON_PRESSED, NOT_IN_ISR);
+				badge_input_add_event(id, EVENT_BUTTON_PRESSED, NOT_IN_ISR);
 			}
 		}
 	}
@@ -48,7 +48,7 @@ touch_event_handler(int event)
 void
 mpr121_event_handler(void *b)
 {
-	badge_input_add_event((uint32_t) b, BUTTON_PRESSED, NOT_IN_ISR);
+	badge_input_add_event((uint32_t) b, EVENT_BUTTON_PRESSED, NOT_IN_ISR);
 }
 #endif // I2C_MPR121_ADDR
 

--- a/components/badge/badge_button.c
+++ b/components/badge/badge_button.c
@@ -18,7 +18,7 @@ badge_button_handler(void *arg)
 	if (new_state == 0 && badge_button_old_state[gpio_num] != 0)
 	{
 		uint32_t button_down = badge_button_conv[gpio_num];
-		xQueueSendFromISR(badge_input_queue, &button_down, NULL);
+		badge_input_add_event(button_down, true, true);
 	}
 	badge_button_old_state[gpio_num] = new_state;
 }

--- a/components/badge/badge_button.c
+++ b/components/badge/badge_button.c
@@ -18,7 +18,7 @@ badge_button_handler(void *arg)
 	if (new_state == 0 && badge_button_old_state[gpio_num] != 0)
 	{
 		uint32_t button_down = badge_button_conv[gpio_num];
-		badge_input_add_event(button_down, BUTTON_PRESSED, IN_ISR);
+		badge_input_add_event(button_down, EVENT_BUTTON_PRESSED, IN_ISR);
 	}
 	badge_button_old_state[gpio_num] = new_state;
 }

--- a/components/badge/badge_button.c
+++ b/components/badge/badge_button.c
@@ -18,7 +18,7 @@ badge_button_handler(void *arg)
 	if (new_state == 0 && badge_button_old_state[gpio_num] != 0)
 	{
 		uint32_t button_down = badge_button_conv[gpio_num];
-		badge_input_add_event(button_down, true, true);
+		badge_input_add_event(button_down, BUTTON_PRESSED, IN_ISR);
 	}
 	badge_button_old_state[gpio_num] = new_state;
 }

--- a/components/badge/badge_button.h
+++ b/components/badge/badge_button.h
@@ -3,8 +3,5 @@
 
 extern void badge_button_add(int gpio_num, uint32_t button_id);
 
-extern void badge_touch_intr_handler(void *arg);
-extern void badge_button_handler(void *arg);
-
 #endif // BADGE_BUTTON_H
 

--- a/components/badge/badge_input.c
+++ b/components/badge/badge_input.c
@@ -5,9 +5,25 @@
 #include "badge_input.h"
 
 xQueueHandle badge_input_queue = NULL;
+void (*badge_input_notify)(void);
 
 void
 badge_input_init(void)
 {
 	badge_input_queue = xQueueCreate(10, sizeof(uint32_t));
+}
+
+void
+badge_input_add_event(uint32_t button_id, bool down, bool in_isr)
+{
+	if (down)
+	{
+		if (in_isr)
+			xQueueSendFromISR(badge_input_queue, &button_id, NULL);
+		else
+			xQueueSend(badge_input_queue, &button_id, 0);
+
+		if (badge_input_notify != NULL)
+			badge_input_notify();
+	}
 }

--- a/components/badge/badge_input.c
+++ b/components/badge/badge_input.c
@@ -14,9 +14,9 @@ badge_input_init(void)
 }
 
 void
-badge_input_add_event(uint32_t button_id, bool down, bool in_isr)
+badge_input_add_event(uint32_t button_id, bool pressed, bool in_isr)
 {
-	if (down)
+	if (pressed)
 	{
 		if (in_isr)
 			xQueueSendFromISR(badge_input_queue, &button_id, NULL);

--- a/components/badge/badge_input.h
+++ b/components/badge/badge_input.h
@@ -22,8 +22,8 @@ extern xQueueHandle badge_input_queue;
 
 extern void badge_input_init(void);
 
-#define BUTTON_RELEASED false
-#define BUTTON_PRESSED  true
+#define EVENT_BUTTON_RELEASED false
+#define EVENT_BUTTON_PRESSED  true
 #define NOT_IN_ISR false
 #define IN_ISR true
 extern void badge_input_add_event(uint32_t button_id, bool pressed, bool in_isr);

--- a/components/badge/badge_input.h
+++ b/components/badge/badge_input.h
@@ -22,4 +22,8 @@ extern xQueueHandle badge_input_queue;
 
 extern void badge_input_init(void);
 
+extern void badge_input_add_event(uint32_t button_id, bool down, bool in_isr);
+
+extern void (*badge_input_notify)(void);
+
 #endif // BADGE_INPUT_H

--- a/components/badge/badge_input.h
+++ b/components/badge/badge_input.h
@@ -22,7 +22,11 @@ extern xQueueHandle badge_input_queue;
 
 extern void badge_input_init(void);
 
-extern void badge_input_add_event(uint32_t button_id, bool down, bool in_isr);
+#define BUTTON_RELEASED false
+#define BUTTON_PRESSED  true
+#define NOT_IN_ISR false
+#define IN_ISR true
+extern void badge_input_add_event(uint32_t button_id, bool pressed, bool in_isr);
 
 extern void (*badge_input_notify)(void);
 

--- a/components/ugfx/ginput_lld_toggle.c
+++ b/components/ugfx/ginput_lld_toggle.c
@@ -14,57 +14,16 @@
 #include <esp_event.h>
 
 #include <badge_input.h>
-#include <badge_pins.h>
-#include <badge_button.h>
 
 #include "ginput_lld_toggle_config.h"
 
 GINPUT_TOGGLE_DECLARE_STRUCTURE();
 
 void
-ginput_toggle_interrupt_handler(void *arg) {
-#ifdef PIN_NUM_BUTTON_A
-	badge_button_handler(arg);
-#endif /* PIN_NUM_BUTTON_A */
-
-#ifdef I2C_TOUCHPAD_ADDR
-	badge_touch_intr_handler(arg);
-#endif /* I2C_TOUCHPAD_ADDR */
-
-	ginputToggleWakeupI();
-}
-
-void
-register_button_interrupt_handler(int gpio_num) {
-	gpio_isr_handler_add(gpio_num, ginput_toggle_interrupt_handler, (void*) gpio_num);
-
-	// configure the gpio pin for input
-	gpio_config_t io_conf;
-	io_conf.intr_type = GPIO_INTR_ANYEDGE;
-	io_conf.mode = GPIO_MODE_INPUT;
-	io_conf.pin_bit_mask = 1LL << gpio_num;
-	io_conf.pull_down_en = 0;
-	io_conf.pull_up_en = 1;
-	gpio_config(&io_conf);
-}
-
-void
 ginput_lld_toggle_init(const GToggleConfig *ptc)
 {
 	ets_printf("ginput_lld_toggle: init()\n");
-#ifdef PIN_NUM_BUTTON_A
-	register_button_interrupt_handler(PIN_NUM_BUTTON_A);
-	register_button_interrupt_handler(PIN_NUM_BUTTON_B);
-	register_button_interrupt_handler(PIN_NUM_BUTTON_MID);
-	register_button_interrupt_handler(PIN_NUM_BUTTON_UP);
-	register_button_interrupt_handler(PIN_NUM_BUTTON_DOWN);
-	register_button_interrupt_handler(PIN_NUM_BUTTON_LEFT);
-	register_button_interrupt_handler(PIN_NUM_BUTTON_RIGHT);
-#endif /* PIN_NUM_BUTTON_A */
-
-#ifdef I2C_TOUCHPAD_ADDR
-	badge_portexp_set_interrupt_handler(PORTEXP_PIN_NUM_TOUCH, ginput_toggle_interrupt_handler, NULL);
-#endif // I2C_TOUCHPAD_ADDR
+	badge_input_notify = ginputToggleWakeupI;
 }
 
 unsigned
@@ -72,14 +31,17 @@ ginput_lld_toggle_getbits(const GToggleConfig *ptc)
 {
 	ets_printf("ginput_lld_toggle: getbits()\n");
 	uint32_t result = 0;
-    uint32_t button_down = 0;
-		// No delay, because we'll be triggered by an interrupt so we know there should be something to read
-    while (xQueueReceive(badge_input_queue, &button_down, 0))
+	uint32_t button_down = 0;
+	// No delay, because we'll be triggered by an interrupt so we know there should be something to read
+	while (xQueueReceive(badge_input_queue, &button_down, 0))
 	{
 		ets_printf("ginput_lld_toggle: button %d pressed\n", button_down);
 		result |= 1 << button_down;
 	}
-	ets_printf("ginput_lld_toggle: no more buttons pressed, final bitmask: %d\n", result);
+
+	if (result == 0)
+		ets_printf("ginput_lld_toggle: no buttons pressed (timeout)\n");
+
 	return result;
 }
 

--- a/components/ugfx/ginput_lld_toggle_config.h
+++ b/components/ugfx/ginput_lld_toggle_config.h
@@ -1,6 +1,9 @@
 #ifndef GINPUT_LLD_TOGGLE_CONFIG
 #define GINPUT_LLD_TOGGLE_CONFIG
 
+// re-export BADGE_BUTTON_* constants
+#include <badge_input.h>
+
 #define GINPUT_TOGGLE_NUM_PORTS       32
 #define GINPUT_TOGGLE_CONFIG_ENTRIES   1
 

--- a/components/ugfx/ginput_lld_toggle_config.h
+++ b/components/ugfx/ginput_lld_toggle_config.h
@@ -1,5 +1,3 @@
-#include "badge_input.h"
-
 #ifndef GINPUT_LLD_TOGGLE_CONFIG
 #define GINPUT_LLD_TOGGLE_CONFIG
 


### PR DESCRIPTION
- add badge_input_notify-hook to hardware-abstraction-framework
- use badge_input_add_event() to add button-presses to the queue
  (and call notify hook if set)
- remove gpio and touch handling from ugfx framework