### PR TITLE
Fixes in low-level drivers

### DIFF
--- a/components/badge/Kconfig
+++ b/components/badge/Kconfig
@@ -34,6 +34,12 @@ config SHA_BADGE_EINK_GDEH029A1
     bool "GDEH029A1"
 endchoice
 
+config SHA_BADGE_INPUT_DEBUG
+    bool "Enable input debug messages"
+    default n
+    help
+        Debugging
+
 config SHA_BADGE_PORTEXP_DEBUG
     bool "Enable port-expander debug messages"
     depends on SHA_BADGE_V2
@@ -51,6 +57,12 @@ config SHA_BADGE_TOUCH_DEBUG
 config SHA_BADGE_MPR121_DEBUG
     bool "Enable MPR121 debug messages"
     depends on SHA_BADGE_V3
+    default n
+    help
+        Debugging
+
+config SHA_BADGE_EINK_DEBUG
+    bool "Enable eink debug messages"
     default n
     help
         Debugging

--- a/components/badge/badge.c
+++ b/components/badge/badge.c
@@ -18,7 +18,8 @@ void
 touch_event_handler(int event)
 {
 	// convert into button queue event
-	if (((event >> 16) & 0x0f) == 0x0) { // button down event
+	int event_type = (event >> 16) & 0x0f; // 0=touch, 1=release, 2=slider
+	if (event_type == 0 || event_type == 1) {
 		static const int conv[12] = {
 			-1,
 			-1,
@@ -37,7 +38,7 @@ touch_event_handler(int event)
 			int id = conv[(event >> 8) & 0xff];
 			if (id != -1)
 			{
-				badge_input_add_event(id, EVENT_BUTTON_PRESSED, NOT_IN_ISR);
+				badge_input_add_event(id, event_type == 0 ? EVENT_BUTTON_PRESSED : EVENT_BUTTON_RELEASED, NOT_IN_ISR);
 			}
 		}
 	}
@@ -46,9 +47,9 @@ touch_event_handler(int event)
 
 #ifdef I2C_MPR121_ADDR
 void
-mpr121_event_handler(void *b)
+mpr121_event_handler(void *b, bool pressed)
 {
-	badge_input_add_event((uint32_t) b, EVENT_BUTTON_PRESSED, NOT_IN_ISR);
+	badge_input_add_event((uint32_t) b, pressed ? EVENT_BUTTON_PRESSED : EVENT_BUTTON_RELEASED, NOT_IN_ISR);
 }
 #endif // I2C_MPR121_ADDR
 

--- a/components/badge/badge_button.c
+++ b/components/badge/badge_button.c
@@ -15,10 +15,10 @@ badge_button_handler(void *arg)
 	uint32_t gpio_num = (uint32_t) arg;
 
 	int new_state = gpio_get_level(gpio_num);
-	if (new_state == 0 && badge_button_old_state[gpio_num] != 0)
+	if (new_state != badge_button_old_state[gpio_num])
 	{
-		uint32_t button_down = badge_button_conv[gpio_num];
-		badge_input_add_event(button_down, EVENT_BUTTON_PRESSED, IN_ISR);
+		uint32_t button_id = badge_button_conv[gpio_num];
+		badge_input_add_event(button_id, new_state == 0 ? EVENT_BUTTON_PRESSED : EVENT_BUTTON_RELEASED, IN_ISR);
 	}
 	badge_button_old_state[gpio_num] = new_state;
 }
@@ -27,7 +27,7 @@ void
 badge_button_add(int gpio_num, uint32_t button_id)
 {
 	badge_button_conv[gpio_num] = button_id;
-	badge_button_old_state[gpio_num] = -1;
+	badge_button_old_state[gpio_num] = 1; // released
 
 	gpio_isr_handler_add(gpio_num, badge_button_handler, (void*) gpio_num);
 

--- a/components/badge/badge_eink_dev.c
+++ b/components/badge/badge_eink_dev.c
@@ -51,22 +51,21 @@ void gdeBusyWait(void) {
 	}
 }
 
-#define BADGE_GDE_DEBUG
 void
 badge_gde_intr_handler(void *arg)
 {
 	int gpio_state = gpio_get_level(PIN_NUM_EPD_BUSY);
-#ifdef BADGE_GDE_DEBUG
+#ifdef CONFIG_SHA_BADGE_EINK_DEBUG
 	static int gpio_last_state = -1;
 	if (gpio_last_state != gpio_state)
 	{
 		if (gpio_state == 1)
-			ets_printf("EPD-Busy Int down\n");
+			ets_printf("badge_eink_dev: EPD-Busy Int down\n");
 		else if (gpio_state == 0)
-			ets_printf("EPD-Busy Int up\n");
+			ets_printf("badge_eink_dev: EPD-Busy Int up\n");
 	}
 	gpio_last_state = gpio_state;
-#endif // BADGE_GDE_DEBUG
+#endif // CONFIG_SHA_BADGE_EINK_DEBUG
 
 #ifdef PIN_NUM_LED
 	// pass on BUSY signal to LED.
@@ -118,7 +117,6 @@ void gdeInit(void) {
 	gpio_set_direction(PIN_NUM_EPD_DATA, GPIO_MODE_OUTPUT);
 	gpio_set_direction(PIN_NUM_EPD_RESET, GPIO_MODE_OUTPUT);
 	gpio_set_direction(PIN_NUM_EPD_BUSY, GPIO_MODE_INPUT);
-	ets_printf("epd spi pin mux init ...\r\n");
 	gpio_matrix_out(PIN_NUM_EPD_MOSI, VSPID_OUT_IDX, 0, 0);
 	gpio_matrix_out(PIN_NUM_EPD_CLK, VSPICLK_OUT_IDX, 0, 0);
 	gpio_matrix_out(PIN_NUM_EPD_CS, VSPICS0_OUT_IDX, 0, 0);

--- a/components/badge/badge_input.c
+++ b/components/badge/badge_input.c
@@ -16,6 +16,22 @@ badge_input_init(void)
 void
 badge_input_add_event(uint32_t button_id, bool pressed, bool in_isr)
 {
+#ifdef CONFIG_SHA_BADGE_INPUT_DEBUG
+	const char *button_name[11] = {
+		"(null)",
+		"UP",
+		"DOWN",
+		"LEFT",
+		"RIGHT",
+		"MID",
+		"A",
+		"B",
+		"SELECT",
+		"START",
+		"FLASH",
+	};
+	ets_printf("badge_input: Button %s %s.\n", button_name[button_id < 11 ? button_id : 0], pressed ? "pressed" : "released");
+#endif // CONFIG_SHA_BADGE_INPUT_DEBUG
 	if (pressed)
 	{
 		if (in_isr)

--- a/components/badge/badge_mpr121.h
+++ b/components/badge/badge_mpr121.h
@@ -1,7 +1,10 @@
 #ifndef BADGE_MPR121_H
 #define BADGE_MPR121_H
 
-typedef void (*badge_mpr121_intr_t)(void*);
+#include <stdbool.h>
+#include <stdint.h>
+
+typedef void (*badge_mpr121_intr_t)(void*, bool);
 
 extern void badge_mpr121_init(void);
 

--- a/components/badge/badge_portexp.c
+++ b/components/badge/badge_portexp.c
@@ -49,12 +49,12 @@ badge_portexp_read_reg(uint8_t reg)
 	esp_err_t ret = badge_i2c_read_reg(I2C_PORTEXP_ADDR, reg, &value);
 
 	if (ret == ESP_OK) {
-#ifdef SHA_BADGE_PORTEXP_DEBUG
-		ets_printf("i2c read reg(0x%02x): 0x%02x\n", reg, value);
-#endif // SHA_BADGE_PORTEXP_DEBUG
+#ifdef CONFIG_SHA_BADGE_PORTEXP_DEBUG
+		ets_printf("badge_portexp: i2c read reg(0x%02x): 0x%02x\n", reg, value);
+#endif // CONFIG_SHA_BADGE_PORTEXP_DEBUG
 		return value;
 	} else {
-		ets_printf("i2c read reg(0x%02x): error %d\n", reg, ret);
+		ets_printf("badge_portexp: i2c read reg(0x%02x): error %d\n", reg, ret);
 		return -1;
 	}
 }
@@ -65,12 +65,12 @@ badge_portexp_write_reg(uint8_t reg, uint8_t value)
 	esp_err_t ret = badge_i2c_write_reg(I2C_PORTEXP_ADDR, reg, value);
 
 	if (ret == ESP_OK) {
-#ifdef SHA_BADGE_PORTEXP_DEBUG
-		ets_printf("i2c write reg(0x%02x, 0x%02x): ok\n", reg, value);
-#endif // SHA_BADGE_PORTEXP_DEBUG
+#ifdef CONFIG_SHA_BADGE_PORTEXP_DEBUG
+		ets_printf("badge_portexp: i2c write reg(0x%02x, 0x%02x): ok\n", reg, value);
+#endif // CONFIG_SHA_BADGE_PORTEXP_DEBUG
 		return 0;
 	} else {
-		ets_printf("i2c write reg(0x%02x, 0x%02x): error %d\n", reg, value, ret);
+		ets_printf("badge_portexp: i2c write reg(0x%02x, 0x%02x): error %d\n", reg, value, ret);
 		return -1;
 	}
 }
@@ -111,17 +111,17 @@ badge_portexp_intr_handler(void *arg)
 {
 
 	int gpio_state = gpio_get_level(PIN_NUM_PORTEXP_INT);
-#ifdef SHA_BADGE_PORTEXP_DEBUG
+#ifdef CONFIG_SHA_BADGE_PORTEXP_DEBUG
 	static int gpio_last_state = -1;
 	if (gpio_last_state != gpio_state)
 	{
 		if (gpio_state == 1)
-			ets_printf("I2C Int down\n");
+			ets_printf("badge_portexp: I2C Int down\n");
 		else if (gpio_state == 0)
-			ets_printf("I2C Int up\n");
+			ets_printf("badge_portexp: I2C Int up\n");
 	}
 	gpio_last_state = gpio_state;
-#endif // SHA_BADGE_PORTEXP_DEBUG
+#endif // CONFIG_SHA_BADGE_PORTEXP_DEBUG
 
 	if (gpio_state == 0)
 	{

--- a/components/badge/badge_touch.c
+++ b/components/badge/badge_touch.c
@@ -24,12 +24,12 @@ badge_touch_read_event(void)
 	esp_err_t ret = badge_i2c_read_event(I2C_TOUCHPAD_ADDR, buf);
 
 	if (ret == ESP_OK) {
-#ifdef SHA_BADGE_TOUCH_DEBUG
-		ets_printf("event: 0x%02x, 0x%02x, 0x%02x\n", buf[0], buf[1], buf[2]);
-#endif // SHA_BADGE_TOUCH_DEBUG
+#ifdef CONFIG_SHA_BADGE_TOUCH_DEBUG
+		ets_printf("badge_touch: event: 0x%02x, 0x%02x, 0x%02x\n", buf[0], buf[1], buf[2]);
+#endif // CONFIG_SHA_BADGE_TOUCH_DEBUG
 		return (buf[0] << 16) | (buf[1] << 8) | (buf[2]);
 	} else {
-		ets_printf("i2c master read (touch-controller): error %d\n", ret);
+		ets_printf("badge_touch: i2c master read: error %d\n", ret);
 		return -1;
 	}
 }


### PR DESCRIPTION
- add config options for input and eink debug
- add button-release handling
- prefix every printf message with its driver name
  e.g. 'badge_mpr121: i2c read reg(0x%02x): 0x%02x\n'
- mpr121: improve interrupt handling
  - better error-handling
  - better handling of multi-button presses
  - handling of over-current situation
- mpr121: read gpio-level from status register, not from data-register.