### PR TITLE
Moved button definitions to a header that doesn't depend on FreeRTOS queues

### DIFF
--- a/components/badge/badge_button.h
+++ b/components/badge/badge_button.h
@@ -3,5 +3,24 @@
 
 extern void badge_button_add(int gpio_num, uint32_t button_id);
 
+#define BADGE_BUTTON_UP      1
+#define BADGE_BUTTON_DOWN    2
+#define BADGE_BUTTON_LEFT    3
+#define BADGE_BUTTON_RIGHT   4
+#define BADGE_BUTTON_MID     5
+#define BADGE_BUTTON_A       6
+#define BADGE_BUTTON_B       7
+#define BADGE_BUTTON_SELECT  8
+#define BADGE_BUTTON_START   9
+#define BADGE_BUTTON_FLASH  10
+
+// Number of buttons on the badge
+#define BADGE_BUTTONS 10
+
+#define EVENT_BUTTON_RELEASED false
+#define EVENT_BUTTON_PRESSED  true
+#define NOT_IN_ISR false
+#define IN_ISR true
+
 #endif // BADGE_BUTTON_H
 

--- a/components/badge/badge_input.h
+++ b/components/badge/badge_input.h
@@ -2,15 +2,10 @@
 #define BADGE_INPUT_H
 
 #include <sdkconfig.h>
-#ifndef UNIX
 #include <freertos/FreeRTOS.h>
 #include <esp_event.h>
-extern xQueueHandle badge_input_queue;
-#else
-#include <stdbool.h>
-#include <stdint.h>
-#endif
 
+extern xQueueHandle badge_input_queue;
 #define BADGE_BUTTON_UP      1
 #define BADGE_BUTTON_DOWN    2
 #define BADGE_BUTTON_LEFT    3

--- a/components/badge/badge_input.h
+++ b/components/badge/badge_input.h
@@ -6,26 +6,9 @@
 #include <esp_event.h>
 
 extern xQueueHandle badge_input_queue;
-#define BADGE_BUTTON_UP      1
-#define BADGE_BUTTON_DOWN    2
-#define BADGE_BUTTON_LEFT    3
-#define BADGE_BUTTON_RIGHT   4
-#define BADGE_BUTTON_MID     5
-#define BADGE_BUTTON_A       6
-#define BADGE_BUTTON_B       7
-#define BADGE_BUTTON_SELECT  8
-#define BADGE_BUTTON_START   9
-#define BADGE_BUTTON_FLASH  10
-
-// Number of buttons on the badge
-#define BADGE_BUTTONS 10
 
 extern void badge_input_init(void);
 
-#define EVENT_BUTTON_RELEASED false
-#define EVENT_BUTTON_PRESSED  true
-#define NOT_IN_ISR false
-#define IN_ISR true
 extern void badge_input_add_event(uint32_t button_id, bool pressed, bool in_isr);
 
 extern void (*badge_input_notify)(void);

--- a/components/badge/badge_input.h
+++ b/components/badge/badge_input.h
@@ -2,10 +2,15 @@
 #define BADGE_INPUT_H
 
 #include <sdkconfig.h>
+#ifndef UNIX
 #include <freertos/FreeRTOS.h>
 #include <esp_event.h>
-
 extern xQueueHandle badge_input_queue;
+#else
+#include <stdbool.h>
+#include <stdint.h>
+#endif
+
 #define BADGE_BUTTON_UP      1
 #define BADGE_BUTTON_DOWN    2
 #define BADGE_BUTTON_LEFT    3


### PR DESCRIPTION
In order to make the button interface reusable on unix, it will be nicer to have these defines in a header that doesn't bring along other dependencies.