### PR TITLE
Main apps require badge_button.h now

### DIFF
--- a/main/demo_ugfx.c
+++ b/main/demo_ugfx.c
@@ -1,6 +1,7 @@
 #include "gfx.h"
 #include "demo_ugfx.h"
 #include "badge_input.h"
+#include "badge_button.h"
 #include "ginput/ginput_driver_toggle.h"
 
 font_t roboto;

--- a/main/main.c
+++ b/main/main.c
@@ -10,6 +10,7 @@
 
 #include <badge.h>
 #include <badge_input.h>
+#include <badge_button.h>
 #include <badge_eink.h>
 #include <badge_pins.h>
 


### PR DESCRIPTION
After moving button definitions to their own header, apps need to use this include.