### PR TITLE
rewrite badge_leds driver a bit;

### DIFF
--- a/components/badge/Kconfig
+++ b/components/badge/Kconfig
@@ -38,6 +38,15 @@ config SHA_BADGE_EINK_GDEH029A1
     bool "GDEH029A1"
 endchoice
 
+config SHA_BADGE_LEDS_WS2812
+    bool "Using WS2812 LEDS instead of SK6812"
+    depends on SHA_BADGE_V2 || SHA_BADGE_V3
+    default n
+    help
+        On earlier developer boards, WS2812 leds were used
+        instead of SK6812. This option modifies the data
+        stream to emulate the SK6812 LEDS.
+
 config SHA_BADGE_INPUT_DEBUG
     bool "Enable input debug messages"
     default n

--- a/components/badge/badge_leds.c
+++ b/components/badge/badge_leds.c
@@ -73,14 +73,14 @@ badge_leds_send_data(uint8_t *data, int len)
 	int i;
 	for (i=0; i<len; i++)
 	{
-		int v = rgbw[i];
+		int v = data[i];
 #ifdef CONFIG_SHA_BADGE_LEDS_WS2812
 		// the WS2812 doesn't have a white led; evenly distribute over other leds.
 		if (i < 6*4) // only do conversion for the internal leds
 		{
 			if ((i & 3) == 3)
 				continue; // skip the white pixel
-			int w = ((i|3) < len) ? rgbw[i|3] : 0;
+			int w = ((i|3) < len) ? data[i|3] : 0;
 			v += w;
 			if (v > 255)
 				v = 255;

--- a/components/badge/badge_leds.h
+++ b/components/badge/badge_leds.h
@@ -4,6 +4,11 @@
 #include <stdint.h>
 
 extern void badge_leds_init(void);
+
+extern int badge_leds_enable(void);
+extern int badge_leds_disable(void);
+
 extern int badge_leds_set_state(uint8_t *rgbw);
+extern int badge_leds_send_data(uint8_t *data, int len);
 
 #endif // BADGE_LEDS_H

--- a/components/badge/badge_pins.h
+++ b/components/badge/badge_pins.h
@@ -76,7 +76,6 @@
 
 // Badge revision 1.0.x
 #define PIN_NUM_LEDS         32
-#define SK6812RGBW
 
 #define PIN_NUM_BUTTON_FLASH  0
 


### PR DESCRIPTION
- add badge_leds_enable() to enable power to the leds bar.
- add badge_leds_disable() to disable power to the leds bar.
- add badge_leds_send_data(data, len) to send a data-stream to the leds-bar.
  (with arbitrary length to support external leds-bar)
- move the WS2812 / SK6812 selection from badge_pins.h to the config-menu.
  WS2812 is now a hack on the data-stream sent with badge_leds_send_data()