### PR TITLE
Improve eink-display; add partial-updates to depg driver

### DIFF
--- a/components/badge/Kconfig
+++ b/components/badge/Kconfig
@@ -90,4 +90,11 @@ config SHA_BADGE_EINK_DEBUG
     help
         Debugging
 
+config SHA_BADGE_EINK_LUT_DEBUG
+    bool "Enable eink lookup-table debug messages"
+    depends on SHA_BADGE_V1 || SHA_BADGE_V2 || SHA_BADGE_V3
+    default n
+    help
+        Debugging
+
 endmenu

--- a/components/badge/badge_eink.h
+++ b/components/badge/badge_eink.h
@@ -4,32 +4,50 @@
 
 #include <stdint.h>
 
+/** the width of the eink display */
 #define BADGE_EINK_WIDTH  296
+/** the height of the eink display */
 #define BADGE_EINK_HEIGHT 128
 
+/** Initialize the eink display */
 extern void badge_eink_init(void);
 
-/* badge_eink_update 'lut' settings */
-#define BADGE_EINK_LUT_CUSTOM  -1
-#define BADGE_EINK_LUT_FULL     0
-#define BADGE_EINK_LUT_NORMAL   1
-#define BADGE_EINK_LUT_FASTER   2
-#define BADGE_EINK_LUT_FASTEST  3
-#define BADGE_EINK_LUT_DEFAULT  BADGE_EINK_LUT_FULL
-#define BADGE_EINK_LUT_MAX      BADGE_EINK_LUT_FASTEST
+/** badge_eink_update 'lut' settings */
+enum badge_eink_lut
+{
+	BADGE_EINK_LUT_CUSTOM  = -1,
+	BADGE_EINK_LUT_FULL    =  0,
+	BADGE_EINK_LUT_NORMAL  =  1,
+	BADGE_EINK_LUT_FASTER  =  2,
+	BADGE_EINK_LUT_FASTEST =  3,
+	BADGE_EINK_LUT_DEFAULT = BADGE_EINK_LUT_FULL,
+	BADGE_EINK_LUT_MAX     = BADGE_EINK_LUT_FASTEST,
+};
 
+/** config-settings structure */
 struct badge_eink_update {
+	/** lut index */
 	int lut;
-	const uint8_t *lut_custom;
+	/** optional lut flags */
+	int lut_flags;
+	/** the raw lut data if BADGE_EINK_LUT_CUSTOM is selected */
+	const struct badge_eink_lut_entry *lut_custom;
+	/** raw setting for the number of dummy lines */
 	int reg_0x3a;
+	/** raw setting for the time per line */
 	int reg_0x3b;
+	/** the start column for partial-screen-updates */
 	int y_start;
+	/** the end column for partial-screen-updates */
 	int y_end;
 };
 
-// default config for convenience
+/** default config for convenience */
 extern const struct badge_eink_update eink_upd_default;
 
+/** refresh the eink display with given config-settings
+ * @param upd_conf the config-settings to use
+ */
 extern void badge_eink_update(const struct badge_eink_update *upd_conf);
 
 /* badge_eink_display 'mode' settings */
@@ -37,9 +55,11 @@ extern void badge_eink_update(const struct badge_eink_update *upd_conf);
 #define DISPLAY_FLAG_GREYSCALE  1
 #define DISPLAY_FLAG_ROTATE_180 2
 #define DISPLAY_FLAG_NO_UPDATE  4
+#define DISPLAY_FLAG_FULL_UPDATE 8
 // fields and sizes:
 #define DISPLAY_FLAG_LUT_BIT    8
 #define DISPLAY_FLAG_LUT_SIZE   4
+#define DISPLAY_FLAG_LUT(x) ((1+(x)) << DISPLAY_FLAG_LUT_BIT)
 
 /*
  * display image on badge

--- a/components/badge/badge_eink_lut.c
+++ b/components/badge/badge_eink_lut.c
@@ -1,125 +1,213 @@
 #include "sdkconfig.h"
 
 #include <stdint.h>
+#include <string.h>
+
+#include <rom/ets_sys.h>
 
 #include "badge_eink_lut.h"
+
+// full, includes inverting
+const struct badge_eink_lut_entry badge_eink_lut_full[] = {
+	{ .length = 23, .voltages = 0x02, },
+	{ .length =  4, .voltages = 0x01, },
+	{ .length = 11, .voltages = 0x11, },
+	{ .length =  4, .voltages = 0x12, },
+	{ .length =  6, .voltages = 0x22, },
+	{ .length =  5, .voltages = 0x66, },
+	{ .length =  4, .voltages = 0x69, },
+	{ .length =  5, .voltages = 0x59, },
+	{ .length =  1, .voltages = 0x58, },
+	{ .length = 14, .voltages = 0x99, },
+	{ .length =  1, .voltages = 0x88, },
+	{ .length = 0 }
+};
+
+// full, no inversion
+const struct badge_eink_lut_entry badge_eink_lut_normal[] = {
+	{ .length =  3, .voltages = 0x10, },
+	{ .length =  5, .voltages = 0x18, },
+	{ .length =  1, .voltages = 0x08, },
+	{ .length =  8, .voltages = 0x18, },
+	{ .length =  2, .voltages = 0x08, },
+	{ .length = 0 }
+};
+
+// full, no inversion, needs 2 updates for full update
+const struct badge_eink_lut_entry badge_eink_lut_faster[] = {
+	{ .length =  1, .voltages = 0x10, },
+	{ .length =  8, .voltages = 0x18, },
+	{ .length =  1, .voltages = 0x08, },
+	{ .length = 0 }
+};
+
+// full, no inversion, needs 4 updates for full update
+const struct badge_eink_lut_entry badge_eink_lut_fastest[] = {
+	{ .length =  1, .voltages = 0x10, },
+	{ .length =  5, .voltages = 0x18, },
+	{ .length =  1, .voltages = 0x08, },
+	{ .length = 0 }
+};
+
+static uint8_t
+badge_eink_lut_conv(uint8_t voltages, enum badge_eink_lut_flags flags)
+{
+	if (flags & LUT_FLAG_FIRST)
+	{
+		voltages |= voltages >> 4;
+		voltages &= 15;
+		if ((voltages & 3) == 3) // reserved
+			voltages ^= 2; // set to '1': VSH (black)
+		if ((voltages & 12) == 12) // reserved
+			voltages ^= 4; // set to '2': VSL (white)
+		voltages |= voltages << 4;
+	}
+
+	if (flags & LUT_FLAG_PARTIAL)
+		voltages &= 0x3c; // only keep 0->1 and 1->0
+
+	if (flags & LUT_FLAG_WHITE)
+		voltages &= 0xcc; // only keep 0->1 and 1->1
+
+	if (flags & LUT_FLAG_BLACK)
+		voltages &= 0x33; // only keep 0->0 and 1->0
+
+	return voltages;
+}
+
 
 // GDEH029A1
 #ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 
-// full, includes inverting
-const uint8_t badge_eink_lut_full[30] = {
-	/* VS */
-	0x02, 0x02, 0x01, 0x11, 0x12, 0x12, 0x22, 0x22, 0x66, 0x69,
-	0x69, 0x59, 0x58, 0x99, 0x99, 0x88, 0x00, 0x00, 0x00, 0x00,
-	/* TP */
-	0xF8, 0xB4, 0x13, 0x51, 0x35, 0x51, 0x51, 0x19, 0x01, 0x00,
-};
+uint8_t *
+badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags)
+{
+	static uint8_t lut[30];
+#ifdef CONFIG_SHA_BADGE_EINK_LUT_DEBUG
+	ets_printf("badge_eink_lut_generate: flags = %d.\n", flags);
+#endif // CONFIG_SHA_BADGE_EINK_LUT_DEBUG
 
-// full, no inversion
-const uint8_t badge_eink_lut_normal[30] = {
-    /* VS */
-	0x10, 0x18, 0x18, 0x08, 0x18, 0x18, 0x08, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    /* TP */
-    0x13, 0x14, 0x44, 0x12, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
+	memset(lut, 0, sizeof(lut));
 
-// full, no inversion, needs 2 updates for full update
-const uint8_t badge_eink_lut_faster[30] = {
-    /* VS */
-	0x10, 0x18, 0x18, 0x18, 0x18, 0x08, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-    /* TP */
-    0x11, 0x11, 0x11, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
+	int pos = 0;
+	while (list->length != 0)
+	{
+		uint8_t voltages = badge_eink_lut_conv(list->voltages, flags);
+		int len = list->length;
+		while (len > 0)
+		{
+			int plen = len > 15 ? 15 : len;
+			if (pos == 20)
+			{
+				ets_printf("badge_eink_lut_generate: lut overflow.\n");
+				return NULL; // full
+			}
+			lut[pos] = voltages;
+			if ((pos & 1) == 0)
+				lut[20+(pos >> 1)] = plen;
+			else
+				lut[20+(pos >> 1)] |= plen << 4;
+			len -= plen;
+			pos++;
+		}
 
-// full, no inversion, needs 4 updates for full update
-const uint8_t badge_eink_lut_fastest[30] = {
-	/* VS */
-	0x99, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	/* TP */
-	0x0f, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-};
+		list = &list[1];
+	}
+
+	// the GDEH029A01 needs an empty update cycle at the end.
+	if (pos == 20)
+	{
+		ets_printf("badge_eink_lut_generate: lut overflow.\n");
+		return NULL; // full
+	}
+	if ((pos & 1) == 0)
+		lut[20+(pos >> 1)] = 1;
+	else
+		lut[20+(pos >> 1)] |= 1 << 4;
+
+#ifdef CONFIG_SHA_BADGE_EINK_LUT_DEBUG
+	ets_printf("badge_eink_lut_generate: dump.\n");
+	int i;
+	for (i=0; i<30; i++)
+	{
+		ets_printf(" %02x", lut[i]);
+		if ((i % 10) == 9)
+			ets_printf("\n");
+	}
+#endif // CONFIG_SHA_BADGE_EINK_LUT_DEBUG
+
+	return lut;
+}
 
 // DEPG0290B01
 #elif defined( CONFIG_SHA_BADGE_EINK_DEPG0290B1 )
 
-// full, includes inverting
-const uint8_t badge_eink_lut_full[70] = {
-	0xa0, 0x90, 0x50, 0x00, 0x00, 0x00, 0x00,
-	0x50, 0x90, 0xa0, 0x00, 0x00, 0x00, 0x00,
-	0xa0, 0x90, 0x50, 0x00, 0x00, 0x00, 0x00,
-	0x50, 0x90, 0xa0, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+uint8_t *
+badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags)
+{
+	static uint8_t lut[70];
+#ifdef CONFIG_SHA_BADGE_EINK_LUT_DEBUG
+	ets_printf("badge_eink_lut_generate: flags = %d.\n", flags);
+#endif // CONFIG_SHA_BADGE_EINK_LUT_DEBUG
 
-	0x0f, 0x0f, 0x00, 0x00, 0x00,
-	0x0f, 0x0f, 0x00, 0x00, 0x00,
-	0x0f, 0x0f, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-};
+	memset(lut, 0, sizeof(lut));
 
-// full, no inversion
-const uint8_t badge_eink_lut_normal[70] = {
-	0x00, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0x80, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0x40, 0x40, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+	int pos = 0;
+	int spos = 0;
+	while (list->length != 0)
+	{
+		int len = list->length;
+		if (pos == 7)
+		{
+			ets_printf("badge_eink_lut_generate: lut overflow.\n");
+			return NULL; // full
+		}
+		uint8_t voltages = badge_eink_lut_conv(list->voltages, flags);
 
-	0x0a, 0x00, 0x00, 0x00, 0x02,
-	0x02, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-};
+		lut[0*7 + pos] |= ((voltages >> 0) & 3) << ((3-spos)*2);
+		lut[1*7 + pos] |= ((voltages >> 2) & 3) << ((3-spos)*2);
+		lut[2*7 + pos] |= ((voltages >> 4) & 3) << ((3-spos)*2);
+		lut[3*7 + pos] |= ((voltages >> 6) & 3) << ((3-spos)*2);
+		lut[5*7 + pos*5 + spos] = len;
+		lut[5*7 + pos*5 + spos] = len;
 
-// full, no inversion, needs 2 updates for full update
-const uint8_t badge_eink_lut_faster[70] = {
-	0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0xa0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0xa0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		spos++;
+		if (spos == 2)
+		{
+			spos = 0;
+			pos++;
+		}
 
-	0x0f, 0x0f, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-};
+		list = &list[1];
+	}
 
-// full, no inversion, needs 4 updates for full update
-const uint8_t badge_eink_lut_fastest[70] = {
-	0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0xa0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0x50, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0xa0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+#ifdef CONFIG_SHA_BADGE_EINK_LUT_DEBUG
+	ets_printf("badge_eink_lut_generate: dump.\n");
+	int i;
+	for (i=0; i<35; i++)
+	{
+		ets_printf(" %02x", lut[i]);
+		if ((i % 7) == 6)
+			ets_printf("\n");
+	}
+	for (; i<70; i++)
+	{
+		ets_printf(" %02x", lut[i]);
+		if ((i % 5) == 4)
+			ets_printf("\n");
+	}
+#endif // CONFIG_SHA_BADGE_EINK_LUT_DEBUG
 
-	0x08, 0x08, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-	0x00, 0x00, 0x00, 0x00, 0x00,
-};
+	return lut;
+}
 
 #else
 
-// add dummy entries
-const uint8_t badge_eink_lut_full[0] = { };
-const uint8_t badge_eink_lut_normal[0] = { };
-const uint8_t badge_eink_lut_faster[0] = { };
-const uint8_t badge_eink_lut_fastest[0] = { };
+uint8_t *
+badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags)
+{
+	static uint8_t lut[0];
+	return lut;
+}
 
 #endif

--- a/components/badge/badge_eink_lut.h
+++ b/components/badge/badge_eink_lut.h
@@ -4,10 +4,25 @@
 
 #include <stdint.h>
 
-/* pre-defined lookup-table display-updates. size depends on model. */
-extern const uint8_t badge_eink_lut_full[];     // full, includes inverting
-extern const uint8_t badge_eink_lut_normal[];   // full, no inversion
-extern const uint8_t badge_eink_lut_faster[];   // full, no inversion, needs 2 updates for full update
-extern const uint8_t badge_eink_lut_fastest[];  // full, no inversion, needs 4 updates for full update
+struct badge_eink_lut_entry {
+	uint8_t length;    // 0 = end of list
+	uint8_t voltages;  // bitmap: 11 10 01 00 (from .. to ..)
+	                   // values: 0=VSS, 1=VSH, 2=VSL
+};
+
+enum badge_eink_lut_flags {
+	LUT_FLAG_FIRST    = 1, // do not depend on previous image
+	LUT_FLAG_PARTIAL  = 2, // do not touch already correct pixels
+	LUT_FLAG_WHITE    = 4, // white only
+	LUT_FLAG_BLACK    = 8, // black only
+};
+
+extern uint8_t * badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags);
+
+/* pre-defined lookup-table display-updates. */
+extern const struct badge_eink_lut_entry badge_eink_lut_full[];
+extern const struct badge_eink_lut_entry badge_eink_lut_normal[];
+extern const struct badge_eink_lut_entry badge_eink_lut_faster[];
+extern const struct badge_eink_lut_entry badge_eink_lut_fastest[];
 
 #endif // BADGE_EINK_LUT_H

--- a/components/ugfx/board_framebuffer.h
+++ b/components/ugfx/board_framebuffer.h
@@ -64,7 +64,10 @@ uint8_t target_lut;
 					framebuffer[i * 8 + 1] << 1 |
 					framebuffer[i * 8];
 			}
-			badge_eink_display(target_buffer, target_lut << DISPLAY_FLAG_LUT_BIT);
+			if (target_lut == 0)
+				badge_eink_display(target_buffer, 0);
+			else
+				badge_eink_display(target_buffer, DISPLAY_FLAG_LUT(target_lut - 1));
 			ets_printf("Flushed framebuffer!\n");
 		}
 	#endif

--- a/main/demo_dot1.c
+++ b/main/demo_dot1.c
@@ -2,8 +2,9 @@
 
 #ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 #include <badge_input.h>
-#include <badge_eink.h>
 #include <badge_eink_dev.h>
+#include <badge_eink_lut.h>
+#include <badge_eink.h>
 
 void demoDot1(void) {
   /* clear screen */
@@ -29,10 +30,9 @@ void demoDot1(void) {
   badge_eink_update(&eink_upd);
 
   // init LUT
-  static const uint8_t lut[30] = {
-      //		0x18,0,0,0,0,0,0,0,0,0,
-      0, 0x99, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0,    0, 0, 0, 17, 1, 0, 0, 0, 0, 0, 0, 0, 0,
+  struct badge_eink_lut_entry lut[] = {
+	  { .length = 1, .voltages = 0x99, },
+	  { .length = 0 }
   };
 
   int px = 100;

--- a/main/demo_greyscale2.c
+++ b/main/demo_greyscale2.c
@@ -2,8 +2,9 @@
 
 #ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 #include <badge_input.h>
-#include <badge_eink.h>
 #include <badge_eink_dev.h>
+#include <badge_eink_lut.h>
+#include <badge_eink.h>
 
 void demoGreyscale2(void) {
   int i;
@@ -66,10 +67,10 @@ void demoGreyscale2(void) {
     badge_eink_dev_write_command_end();
 
     /* update LUT */
-    uint8_t lut[30] = {
-        0x18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0,    0, 0, 0, 0, i, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    };
+	struct badge_eink_lut_entry lut[] = {
+		{ .length = i, .voltages = 0x18, },
+		{ .length = 0 }
+	};
 
     struct badge_eink_update eink_upd = {
       .lut      = BADGE_EINK_LUT_CUSTOM,

--- a/main/demo_greyscale_img1.c
+++ b/main/demo_greyscale_img1.c
@@ -2,8 +2,9 @@
 
 #ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 #include <badge_input.h>
-#include <badge_eink.h>
 #include <badge_eink_dev.h>
+#include <badge_eink_lut.h>
+#include <badge_eink.h>
 
 #include "img_hacking.h"
 
@@ -68,10 +69,10 @@ void demoGreyscaleImg1(void) {
     badge_eink_dev_write_command_end();
 
     /* update LUT */
-    uint8_t lut[30] = {
-        0x18, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        0,    0, 0, 0, 0, i, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-    };
+	struct badge_eink_lut_entry lut[] = {
+		{ .length = i, .voltages = 0x18, },
+		{ .length = 0 }
+	};
 
     struct badge_eink_update eink_upd = {
       .lut      = BADGE_EINK_LUT_CUSTOM,

--- a/main/demo_greyscale_img2.c
+++ b/main/demo_greyscale_img2.c
@@ -4,8 +4,9 @@
 #include <string.h>
 
 #include <badge_input.h>
-#include <badge_eink.h>
 #include <badge_eink_dev.h>
+#include <badge_eink_lut.h>
+#include <badge_eink.h>
 
 #include "img_hacking.h"
 
@@ -73,40 +74,14 @@ void demoGreyscaleImg2(void) {
       //   Do nothing when bit is not set;
       //   Make pixel whiter when bit is set;
       //   Duration is <i> cycles.
-      uint8_t lut_[30];
-      if (i <= 15) {
-        uint8_t lut[30] = {
-            0x88, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            0,    0, 0, 0, 0, i, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-        };
-        memcpy(lut_, lut, 30);
-      } else if (i <= 30) {
-        uint8_t lut[30] = {
-            0x88, 0x88, 0, 0, 0, 0, 0,
-            0,    0,    0, 0, 0, 0, 0,
-            0,    0,    0, 0, 0, 0, ((i - 15) << 4) + 15,
-            0,    0,    0, 0, 0, 0, 0,
-            0,    0,
-        };
-        memcpy(lut_, lut, 30);
-      } else if (i <= 45) {
-        uint8_t lut[30] = {
-            0x88, 0x88, 0x88, 0, 0, 0,    0,        0, 0, 0, 0, 0, 0, 0, 0,
-            0,    0,    0,    0, 0, 0xff, (i - 30), 0, 0, 0, 0, 0, 0, 0, 0,
-        };
-        memcpy(lut_, lut, 30);
-      } else if (i <= 60) {
-        uint8_t lut[30] = {
-            0x88, 0x88, 0x88, 0x88, 0, 0, 0, 0, 0, 0,    0,
-            0,    0,    0,    0,    0, 0, 0, 0, 0, 0xff, ((i - 45) << 4) + 15,
-            0,    0,    0,    0,    0, 0, 0, 0,
-        };
-        memcpy(lut_, lut, 30);
-      }
+	  struct badge_eink_lut_entry lut[] = {
+		  { .length = i, .voltages = 0x88, },
+		  { .length = 0 }
+	  };
 
       struct badge_eink_update eink_upd = {
         .lut      = BADGE_EINK_LUT_CUSTOM,
-        .lut_custom = lut_,
+        .lut_custom = lut,
         .reg_0x3a = 0,  // no dummy lines per gate
         .reg_0x3b = 0,  // 30us per line
         .y_start  = y_start,

--- a/main/demo_greyscale_img3.c
+++ b/main/demo_greyscale_img3.c
@@ -2,8 +2,9 @@
 
 #ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 #include <badge_input.h>
-#include <badge_eink.h>
 #include <badge_eink_dev.h>
+#include <badge_eink_lut.h>
+#include <badge_eink.h>
 
 #include "img_hacking.h"
 
@@ -83,10 +84,10 @@ void demoGreyscaleImg3(void) {
       //   Do nothing when bit is not set;
       //   Make pixel whiter when bit is set;
       //   Duration is <ii> cycles.
-      uint8_t lut[30] = {
-          0, 0x88, 0, 0, 0,         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-          0, 0   , 0, 0, 0, (ii<<4)|1, 1, 0, 0, 0, 0, 0, 0, 0, 0,
-      };
+	  struct badge_eink_lut_entry lut[] = {
+		  { .length = ii, .voltages = 0x88, },
+		  { .length = 0 }
+	  };
 
       struct badge_eink_update eink_upd = {
         .lut      = BADGE_EINK_LUT_CUSTOM,

--- a/main/demo_mpr121.c
+++ b/main/demo_mpr121.c
@@ -92,7 +92,7 @@ demoMpr121(void)
 		}
 
 		/* update display */
-		badge_eink_display(screen_buf, (3 << DISPLAY_FLAG_LUT_BIT));
+		badge_eink_display(screen_buf, DISPLAY_FLAG_LUT(2));
 
 		// wait 0.1 second
 		badge_input_get_event(100);

--- a/main/demo_power.c
+++ b/main/demo_power.c
@@ -61,7 +61,7 @@ demoPower(void) {
 					FONT_MONOSPACE | FONT_INVERT);
 
 			/* update display */
-			badge_eink_display(screen_buf, (3 << DISPLAY_FLAG_LUT_BIT));
+			badge_eink_display(screen_buf, DISPLAY_FLAG_LUT(2));
 		}
 
 		// wait 1 second

--- a/main/demo_test_adc.c
+++ b/main/demo_test_adc.c
@@ -47,7 +47,7 @@ demoTestAdc(void) {
 		}
 
 		/* update display */
-		badge_eink_display(screen_buf, (1 << DISPLAY_FLAG_LUT_BIT));
+		badge_eink_display(screen_buf, DISPLAY_FLAG_LUT(0));
 
 		// wait 1 second
 		if (badge_input_get_event(1000) != 0)

--- a/main/demo_text1.c
+++ b/main/demo_text1.c
@@ -20,7 +20,7 @@ demoText1(void) {
 			memset(&screen_buf[y * (BADGE_EINK_WIDTH/8)], (y&1) ? 0x55 : 0xaa, (BADGE_EINK_WIDTH/8));
 		}
 
-		badge_eink_display(screen_buf, (1 << DISPLAY_FLAG_LUT_BIT));
+		badge_eink_display(screen_buf, DISPLAY_FLAG_LUT(0));
 	}
 
 	/* draw text with 8px font */
@@ -64,7 +64,7 @@ demoText1(void) {
 	draw_font(screen_buf, 0, 120, BADGE_EINK_WIDTH, " Just a status line. Wifi status: not connected",
 			FONT_FULL_WIDTH | FONT_MONOSPACE);
 
-	badge_eink_display(screen_buf, (1 << DISPLAY_FLAG_LUT_BIT));
+	badge_eink_display(screen_buf, DISPLAY_FLAG_LUT(0));
 
 	// wait for random keypress
 	badge_input_get_event(-1);

--- a/main/demo_text2.c
+++ b/main/demo_text2.c
@@ -20,7 +20,7 @@ demoText2(void) {
 			memset(&screen_buf[y * (BADGE_EINK_WIDTH/8)], (y&1) ? 0x55 : 0xaa, (BADGE_EINK_WIDTH/8));
 		}
 
-		badge_eink_display(screen_buf, (1 << DISPLAY_FLAG_LUT_BIT));
+		badge_eink_display(screen_buf, DISPLAY_FLAG_LUT(0));
 	}
 
 	/* draw text with 16px font */
@@ -45,7 +45,7 @@ demoText2(void) {
 
 	draw_font(screen_buf, 0, 120, BADGE_EINK_WIDTH, " Just a status line. Wifi status: not connected", FONT_FULL_WIDTH);
 
-	badge_eink_display(screen_buf, (1 << DISPLAY_FLAG_LUT_BIT));
+	badge_eink_display(screen_buf, DISPLAY_FLAG_LUT(0));
 
 	// wait for random keypress
 	badge_input_get_event(-1);


### PR DESCRIPTION
- added partial updates for the depg (write old image to RAM2
  with command 0x26)
- luts are now generated. can now use the same input for both
  display types.
- altered badge_eink_update struct a bit:
  - added lut_flags. bitmapped options:
    - LUT_FLAG_FIRST (no old image available)
    - LUT_FLAG_PARTIAL (remove all non-partial elements)
    - LUT_FLAG_WHITE (only make pixels whiter)
    - LUT_FLAG_BLACK (only make pixels blacker)
  - changed type of lut_custom; it's now in the more generic format.
- added flag DISPLAY_FLAG_FULL_UPDATE, which disables the
  automatic partial update
- added DISPLAY_FLAG_LUT(lut) helper
- removed the fading effect from the menu. it caused too much ghosting.
- improved type definitions and doxygen documentation.