### PR TITLE
Fix issue #59; initialize SPI only on active use

### DIFF
--- a/components/badge/badge_leds.c
+++ b/components/badge/badge_leds.c
@@ -65,8 +65,9 @@ badge_leds_disable(void)
 	assert( ret == ESP_OK );
 	badge_leds_spi = NULL;
 
-	ret = spi_bus_free(HSPI_HOST);
-	assert( ret == ESP_OK );
+//	FIXME: freeing the HSPI seems to (de)configure the VSPI as well..
+//	ret = spi_bus_free(HSPI_HOST);
+//	assert( ret == ESP_OK );
 
 	// configure PIN_NUM_LEDS as high-impedance
 	gpio_config_t io_conf = {
@@ -181,7 +182,7 @@ badge_leds_init(void)
 	if (badge_leds_init_done)
 		return;
 
-	// depending in badge_power
+	// depending on badge_power
 	badge_power_init();
 
 	// configure PIN_NUM_LEDS as high-impedance

--- a/components/badge/badge_power.c
+++ b/components/badge/badge_power.c
@@ -13,31 +13,34 @@
 #include "badge_mpr121.h"
 #include "badge_power.h"
 
-#ifdef ADC1_CHAN_VBAT_SENSE
 int
 badge_battery_volt_sense(void)
 {
+#ifdef ADC1_CHAN_VBAT_SENSE
 	int val = adc1_get_voltage(ADC1_CHAN_VBAT_SENSE);
 	if (val == -1)
 		return -1;
 
 	return (val * 220 * 32) >> 12;
-}
+#else
+	return -1;
 #endif // ADC1_CHAN_VBAT_SENSE
+}
 
-#ifdef ADC1_CHAN_VUSB_SENSE
 int
 badge_usb_volt_sense(void)
 {
+#ifdef ADC1_CHAN_VUSB_SENSE
 	int val = adc1_get_voltage(ADC1_CHAN_VUSB_SENSE);
 	if (val == -1)
 		return -1;
 
 	return (val * 220 * 32) >> 12;
-}
+#else
+	return -1;
 #endif // ADC1_CHAN_VUSB_SENSE
+}
 
-#if defined(PORTEXP_PIN_NUM_CHRGSTAT) || defined(MPR121_PIN_NUM_CHRGSTAT)
 bool
 badge_battery_charge_status(void)
 {
@@ -45,13 +48,127 @@ badge_battery_charge_status(void)
 	return ((badge_portexp_get_input() >> PORTEXP_PIN_NUM_CHRGSTAT) & 1) == 0;
 #elif defined(MPR121_PIN_NUM_CHRGSTAT)
 	return badge_mpr121_get_gpio_level(MPR121_PIN_NUM_CHRGSTAT) == 0;
+#else
+	return false;
 #endif
 }
-#endif // defined(PORTEXP_PIN_NUM_CHRGSTAT) || defined(MPR121_PIN_NUM_CHRGSTAT)
+
+// shared power
+static int badge_power_leds_sdcard = 0; // bit 0 = leds, bit 1 = sd-card
+
+int
+badge_power_leds_enable(void)
+{
+	if (badge_power_leds_sdcard & 1)
+		return 0;
+
+	if (badge_power_leds_sdcard)
+	{
+		badge_power_leds_sdcard |= 1;
+		return 0;
+	}
+
+	int ret;
+#ifdef PORTEXP_PIN_NUM_LEDS
+	ret = badge_portexp_set_output_state(PORTEXP_PIN_NUM_LEDS, 1);
+#elif defined(MPR121_PIN_NUM_LEDS)
+	ret = badge_mpr121_set_gpio_level(MPR121_PIN_NUM_LEDS, 1);
+#else
+	ret = -1;
+#endif
+
+	if (ret == 0)
+		badge_power_leds_sdcard = 1;
+
+	return ret;
+}
+
+int
+badge_power_leds_disable(void)
+{
+	if ((badge_power_leds_sdcard & 1) == 0)
+		return 0;
+
+	if (badge_power_leds_sdcard != 1)
+	{
+		badge_power_leds_sdcard &= ~1;
+		return 0;
+	}
+
+	int ret;
+#ifdef PORTEXP_PIN_NUM_LEDS
+	ret = badge_portexp_set_output_state(PORTEXP_PIN_NUM_LEDS, 0);
+#elif defined(MPR121_PIN_NUM_LEDS)
+	ret = badge_mpr121_set_gpio_level(MPR121_PIN_NUM_LEDS, 0);
+#else
+	ret = -1;
+#endif
+
+	if (ret == 0)
+		badge_power_leds_sdcard = 0;
+
+	return ret;
+}
+
+int
+badge_power_sdcard_enable(void)
+{
+	if (badge_power_leds_sdcard)
+	{
+		badge_power_leds_sdcard |= 2;
+		return 0;
+	}
+
+	int ret;
+#ifdef PORTEXP_PIN_NUM_LEDS
+	ret = badge_portexp_set_output_state(PORTEXP_PIN_NUM_LEDS, 1);
+#elif defined(MPR121_PIN_NUM_LEDS)
+	ret = badge_mpr121_set_gpio_level(MPR121_PIN_NUM_LEDS, 1);
+#else
+	ret = -1;
+#endif
+
+	if (ret == 0)
+		badge_power_leds_sdcard = 2;
+
+	return ret;
+}
+
+int
+badge_power_sdcard_disable(void)
+{
+	if ((badge_power_leds_sdcard & 2) == 0)
+		return 0;
+
+	if (badge_power_leds_sdcard != 2)
+	{
+		badge_power_leds_sdcard &= ~2;
+		return 0;
+	}
+
+	int ret;
+#ifdef PORTEXP_PIN_NUM_LEDS
+	ret = badge_portexp_set_output_state(PORTEXP_PIN_NUM_LEDS, 0);
+#elif defined(MPR121_PIN_NUM_LEDS)
+	ret = badge_mpr121_set_gpio_level(MPR121_PIN_NUM_LEDS, 0);
+#else
+	ret = -1;
+#endif
+
+	if (ret == 0)
+		badge_power_leds_sdcard = 0;
+
+	return ret;
+}
 
 void
 badge_power_init(void)
 {
+	static bool badge_power_init_done = false;
+
+	if (badge_power_init_done)
+		return;
+
 	// configure adc width
 #if defined(ADC1_CHAN_VBAT_SENSE) || defined(ADC1_CHAN_VUSB_SENSE)
 	adc1_config_width(ADC_WIDTH_12Bit);
@@ -80,4 +197,15 @@ badge_power_init(void)
 #elif defined(MPR121_PIN_NUM_CHRGSTAT)
 	badge_mpr121_configure_gpio(MPR121_PIN_NUM_CHRGSTAT, MPR121_INPUT);
 #endif
+
+	// configure power to the leds and sd-card
+#ifdef PORTEXP_PIN_NUM_LEDS
+	badge_portexp_set_output_state(PORTEXP_PIN_NUM_LEDS, 0);
+	badge_portexp_set_output_high_z(PORTEXP_PIN_NUM_LEDS, 0);
+	badge_portexp_set_io_direction(PORTEXP_PIN_NUM_LEDS, 1);
+#elif defined(MPR121_PIN_NUM_LEDS)
+	badge_mpr121_configure_gpio(MPR121_PIN_NUM_LEDS, MPR121_OUTPUT);
+#endif
+
+	badge_power_init_done = true;
 }

--- a/components/badge/badge_power.h
+++ b/components/badge/badge_power.h
@@ -30,4 +30,36 @@ extern int badge_battery_volt_sense(void);
  */
 extern int badge_usb_volt_sense(void);
 
+/**
+ * enable power to the leds-bar
+ *
+ * @return 0 on ok, -1 on error
+ */
+extern int badge_power_leds_enable(void);
+
+/**
+ * disable power to the leds-bar
+ *
+ * @return 0 on ok, -1 on error
+ * @note shared resource: if the power to the sd-card is also enabled,
+ *   the power will stay on.
+ */
+extern int badge_power_leds_disable(void);
+
+/**
+ * enable power to the sd-card
+ *
+ * @return 0 on ok, -1 on error
+ */
+extern int badge_power_sdcard_enable(void);
+
+/**
+ * disable power to the sd-card
+ *
+ * @return 0 on ok, -1 on error
+ * @note shared resource: if the power to the leds-bar is also enabled,
+ *   the power will stay on.
+ */
+extern int badge_power_sdcard_disable(void);
+
 #endif // BADGE_POWER_H

--- a/main/demo_leds.c
+++ b/main/demo_leds.c
@@ -23,15 +23,15 @@
 void demo_leds(void)
 {
 	{
-		uint8_t rgbw[6*4] = {
+		uint8_t grbw[6*4] = {
 			 0,  0,  0,  0,
 			 0,  0,  0,  0,
 			 0,  0,  0, 40,
 			 0,  0, 40,  0,
-			 0, 40,  0,  0,
 			40,  0,  0,  0,
+			 0, 40,  0,  0,
 		}; // show R, G, B, W
-		badge_leds_send_data(rgbw, sizeof(rgbw));
+		badge_leds_send_data(grbw, sizeof(grbw));
 		if (badge_input_get_event(10000) != 0)
 		{
 			badge_leds_disable();
@@ -39,7 +39,7 @@ void demo_leds(void)
 		}
 	}
 
-	uint8_t rgbw[6*4] = {
+	uint8_t grbw[6*4] = {
 		 L0,  L1,  L2, L3,
 		 L1,  L0,  L1, L2,
 		 L2,  L1,  L0, L1,
@@ -62,14 +62,14 @@ void demo_leds(void)
 		if (badge_input_get_event(10) != 0)
 			break;
 
-		badge_leds_send_data(rgbw, sizeof(rgbw));
+		badge_leds_send_data(grbw, sizeof(grbw));
 
 		int i;
 		for (i=0; i<6*4; i++) {
-			rgbw[i] += dir[i];
-			if (rgbw[i] == L0)
+			grbw[i] += dir[i];
+			if (grbw[i] == L0)
 				dir[i] = +1;
-			if (rgbw[i] == L3)
+			if (grbw[i] == L3)
 				dir[i] = -1;
 		}
 	}


### PR DESCRIPTION
 - moved power-handling to badge_power.
 - now initializes the SPI every time we enable the leds-bar.
   (and de-initializes the SPI every time we disable the leds-bar)
 - we're using the gpio driver to ignore the impedance level of the
   pin.
- added call to badge_power_init(); added done flag.

(leds demo)
-  actual ordering of the 'rgbw' colors is 'grbw'.