### PR TITLE
Allow badge_*_init() to be called multiple times.

### DIFF
--- a/components/badge/badge.c
+++ b/components/badge/badge.c
@@ -60,6 +60,11 @@ mpr121_event_handler(void *b, bool pressed)
 void
 badge_init(void)
 {
+	static bool badge_init_done = false;
+
+	if (badge_init_done)
+		return;
+
 	// register isr service
 	badge_base_init();
 
@@ -135,4 +140,6 @@ badge_init(void)
 
 	// configure eink display
 	badge_eink_init();
+
+	badge_init_done = true;
 }

--- a/components/badge/badge.c
+++ b/components/badge/badge.c
@@ -3,6 +3,7 @@
 #include <driver/gpio.h>
 
 #include "badge_pins.h"
+#include "badge_base.h"
 #include "badge_input.h"
 #include "badge_button.h"
 #include "badge_gpiobutton.h"
@@ -59,9 +60,8 @@ mpr121_event_handler(void *b, bool pressed)
 void
 badge_init(void)
 {
-	// install isr-service, so we can register interrupt-handlers per
-	// gpio pin.
-	gpio_install_isr_service(0);
+	// register isr service
+	badge_base_init();
 
 	// configure input queue
 	badge_input_init();

--- a/components/badge/badge_base.c
+++ b/components/badge/badge_base.c
@@ -1,0 +1,22 @@
+#include "sdkconfig.h"
+
+#include <stdbool.h>
+
+#include <driver/gpio.h>
+
+#include "badge_base.h"
+
+void
+badge_base_init(void)
+{
+	static bool badge_base_init_done = false;
+
+	if (badge_base_init_done)
+		return;
+
+	// install isr-service, so we can register interrupt-handlers per
+	// gpio pin.
+	gpio_install_isr_service(0);
+
+	badge_base_init_done = true;
+}

--- a/components/badge/badge_base.h
+++ b/components/badge/badge_base.h
@@ -1,0 +1,10 @@
+/** @file badge_base.h */
+#ifndef BADGE_BASE_H
+#define BADGE_BASE_H
+
+/**
+ * Initialize badge base driver.
+ */
+extern void badge_base_init(void);
+
+#endif // BADGE_BASE_H

--- a/components/badge/badge_eink.c
+++ b/components/badge/badge_eink.c
@@ -327,6 +327,11 @@ badge_eink_wakeup(void)
 void
 badge_eink_init(void)
 {
+	static bool badge_eink_init_done = false;
+
+	if (badge_eink_init_done)
+		return;
+
 	// initialize spi interface to display
 	badge_eink_dev_init();
 
@@ -391,4 +396,6 @@ badge_eink_init(void)
 	// Source voltage setting (15volt, 0 volt and -15 volt)
 	badge_eink_dev_write_command_p3(0x04, 0x41, 0x00, 0x32);
 #endif // CONFIG_SHA_BADGE_EINK_DEPG0290B1
+
+	badge_eink_init_done = true;
 }

--- a/components/badge/badge_eink_dev.c
+++ b/components/badge/badge_eink_dev.c
@@ -15,6 +15,7 @@
 #include <freertos/semphr.h>
 
 #include "badge_pins.h"
+#include "badge_base.h"
 #include "badge_eink_dev.h"
 
 #define SPI_NUM 0x3
@@ -118,6 +119,8 @@ badge_eink_dev_write_command_end(void)
 void
 badge_eink_dev_init(void)
 {
+	badge_base_init();
+
 #ifdef PIN_NUM_LED
 	gpio_pad_select_gpio(PIN_NUM_LED);
 	gpio_set_direction(PIN_NUM_LED, GPIO_MODE_OUTPUT);
@@ -125,12 +128,13 @@ badge_eink_dev_init(void)
 
 	badge_eink_dev_intr_trigger = xSemaphoreCreateBinary();
 	gpio_isr_handler_add(PIN_NUM_EPD_BUSY, badge_eink_dev_intr_handler, NULL);
-	gpio_config_t io_conf;
-	io_conf.intr_type = GPIO_INTR_ANYEDGE;
-	io_conf.mode = GPIO_MODE_INPUT;
-	io_conf.pin_bit_mask = 1LL << PIN_NUM_EPD_BUSY;
-	io_conf.pull_down_en = 0;
-	io_conf.pull_up_en = 1;
+	gpio_config_t io_conf = {
+		.intr_type    = GPIO_INTR_ANYEDGE,
+		.mode         = GPIO_MODE_INPUT,
+		.pin_bit_mask = 1LL << PIN_NUM_EPD_BUSY,
+		.pull_down_en = 0,
+		.pull_up_en   = 1,
+	};
 	gpio_config(&io_conf);
 
 	gpio_set_direction(PIN_NUM_EPD_CS, GPIO_MODE_OUTPUT);

--- a/components/badge/badge_eink_dev.c
+++ b/components/badge/badge_eink_dev.c
@@ -119,6 +119,11 @@ badge_eink_dev_write_command_end(void)
 void
 badge_eink_dev_init(void)
 {
+	static bool badge_eink_dev_init_done = false;
+
+	if (badge_eink_dev_init_done)
+		return;
+
 	badge_base_init();
 
 #ifdef PIN_NUM_LED
@@ -177,6 +182,8 @@ badge_eink_dev_init(void)
 	for (i = 0; i < 16; i++) {
 		WRITE_PERI_REG((SPI_W0_REG(SPI_NUM) + (i << 2)), 0);
 	}
+
+	badge_eink_dev_init_done = true;
 }
 
 void

--- a/components/badge/badge_gpiobutton.c
+++ b/components/badge/badge_gpiobutton.c
@@ -1,8 +1,8 @@
 #include "sdkconfig.h"
 
-//include <freertos/FreeRTOS.h>
 #include <driver/gpio.h>
 
+#include "badge_base.h"
 #include "badge_input.h"
 #include "badge_gpiobutton.h"
 
@@ -26,17 +26,20 @@ badge_gpiobutton_handler(void *arg)
 void
 badge_gpiobutton_add(int gpio_num, uint32_t button_id)
 {
+	badge_base_init();
+
 	badge_gpiobutton_conv[gpio_num] = button_id;
 	badge_gpiobutton_old_state[gpio_num] = 1; // released
 
 	gpio_isr_handler_add(gpio_num, badge_gpiobutton_handler, (void*) gpio_num);
 
 	// configure the gpio pin for input
-	gpio_config_t io_conf;
-	io_conf.intr_type = GPIO_INTR_ANYEDGE;
-	io_conf.mode = GPIO_MODE_INPUT;
-	io_conf.pin_bit_mask = 1LL << gpio_num;
-	io_conf.pull_down_en = 0;
-	io_conf.pull_up_en = 1;
+	gpio_config_t io_conf = {
+		.intr_type    = GPIO_INTR_ANYEDGE,
+		.mode         = GPIO_MODE_INPUT,
+		.pin_bit_mask = 1LL << gpio_num,
+		.pull_down_en = 0,
+		.pull_up_en   = 1,
+	};
 	gpio_config(&io_conf);
 }

--- a/components/badge/badge_i2c.c
+++ b/components/badge/badge_i2c.c
@@ -31,6 +31,11 @@ xSemaphoreHandle badge_i2c_mux = NULL;
 void
 badge_i2c_init(void)
 {
+	static bool badge_i2c_init_done = false;
+
+	if (badge_i2c_init_done)
+		return;
+
 	// create mutex for I2C bus
 	badge_i2c_mux = xSemaphoreCreateMutex();
 
@@ -48,6 +53,8 @@ badge_i2c_init(void)
 	i2c_param_config(I2C_MASTER_NUM, &conf);
 
 	i2c_driver_install(I2C_MASTER_NUM, conf.mode, I2C_MASTER_RX_BUF_DISABLE, I2C_MASTER_TX_BUF_DISABLE, 0);
+
+	badge_i2c_init_done = true;
 }
 
 int

--- a/components/badge/badge_input.c
+++ b/components/badge/badge_input.c
@@ -11,7 +11,14 @@ uint32_t badge_input_button_state = 0;
 void
 badge_input_init(void)
 {
+	static bool badge_input_init_done = false;
+
+	if (badge_input_init_done)
+		return;
+
 	badge_input_queue = xQueueCreate(10, sizeof(uint32_t));
+
+	badge_input_init_done = true;
 }
 
 void

--- a/components/badge/badge_mpr121.c
+++ b/components/badge/badge_mpr121.c
@@ -161,6 +161,11 @@ badge_mpr121_intr_handler(void *arg)
 void
 badge_mpr121_init(const uint32_t *baseline)
 {
+	static bool badge_mpr121_init_done = false;
+
+	if (badge_mpr121_init_done)
+		return;
+
 	badge_base_init();
 
 	badge_mpr121_mux = xSemaphoreCreateMutex();
@@ -224,6 +229,8 @@ badge_mpr121_init(const uint32_t *baseline)
 	xTaskCreate(&badge_mpr121_intr_task, "MPR121 interrupt task", 4096, NULL, 10, NULL);
 
 	badge_mpr121_intr_handler(NULL);
+
+	badge_mpr121_init_done = true;
 }
 
 void

--- a/components/badge/badge_mpr121.c
+++ b/components/badge/badge_mpr121.c
@@ -13,6 +13,7 @@
 #include "freertos/task.h"
 
 #include "badge_pins.h"
+#include "badge_base.h"
 #include "badge_i2c.h"
 #include "badge_mpr121.h"
 
@@ -160,15 +161,18 @@ badge_mpr121_intr_handler(void *arg)
 void
 badge_mpr121_init(const uint32_t *baseline)
 {
+	badge_base_init();
+
 	badge_mpr121_mux = xSemaphoreCreateMutex();
 	badge_mpr121_intr_trigger = xSemaphoreCreateBinary();
 	gpio_isr_handler_add(PIN_NUM_MPR121_INT, badge_mpr121_intr_handler, NULL);
-	gpio_config_t io_conf;
-	io_conf.intr_type = GPIO_INTR_ANYEDGE;
-	io_conf.mode = GPIO_MODE_INPUT;
-	io_conf.pin_bit_mask = 1LL << PIN_NUM_MPR121_INT;
-	io_conf.pull_down_en = 0;
-	io_conf.pull_up_en = 1;
+	gpio_config_t io_conf = {
+		.intr_type    = GPIO_INTR_ANYEDGE,
+		.mode         = GPIO_MODE_INPUT,
+		.pin_bit_mask = 1LL << PIN_NUM_MPR121_INT,
+		.pull_down_en = 0,
+		.pull_up_en   = 1,
+	};
 	gpio_config(&io_conf);
 
 	// soft reset

--- a/components/badge/badge_portexp.c
+++ b/components/badge/badge_portexp.c
@@ -133,6 +133,11 @@ badge_portexp_intr_handler(void *arg)
 void
 badge_portexp_init(void)
 {
+	static bool badge_portexp_init_done = false;
+
+	if (badge_portexp_init_done)
+		return;
+
 	badge_base_init();
 
 	badge_portexp_mux = xSemaphoreCreateMutex();
@@ -181,6 +186,8 @@ badge_portexp_init(void)
 	badge_portexp_read_reg(0x13);
 
 	badge_portexp_intr_handler(NULL);
+
+	badge_portexp_init_done = true;
 }
 
 int

--- a/components/badge/badge_portexp.c
+++ b/components/badge/badge_portexp.c
@@ -13,6 +13,7 @@
 #include "freertos/task.h"
 
 #include "badge_pins.h"
+#include "badge_base.h"
 #include "badge_i2c.h"
 #include "badge_portexp.h"
 
@@ -132,15 +133,18 @@ badge_portexp_intr_handler(void *arg)
 void
 badge_portexp_init(void)
 {
+	badge_base_init();
+
 	badge_portexp_mux = xSemaphoreCreateMutex();
 	badge_portexp_intr_trigger = xSemaphoreCreateBinary();
 	gpio_isr_handler_add(PIN_NUM_PORTEXP_INT, badge_portexp_intr_handler, NULL);
-	gpio_config_t io_conf;
-	io_conf.intr_type = GPIO_INTR_ANYEDGE;
-	io_conf.mode = GPIO_MODE_INPUT;
-	io_conf.pin_bit_mask = 1LL << PIN_NUM_PORTEXP_INT;
-	io_conf.pull_down_en = 0;
-	io_conf.pull_up_en = 1;
+	gpio_config_t io_conf = {
+		.intr_type    = GPIO_INTR_ANYEDGE,
+		.mode         = GPIO_MODE_INPUT,
+		.pin_bit_mask = 1LL << PIN_NUM_PORTEXP_INT,
+		.pull_down_en = 0,
+		.pull_up_en   = 1,
+	};
 	gpio_config(&io_conf);
 
 //	badge_portexp_write_reg(0x01, 0x01); // sw reset

--- a/components/badge/badge_sdcard.c
+++ b/components/badge/badge_sdcard.c
@@ -26,6 +26,11 @@ badge_sdcard_detected(void)
 void
 badge_sdcard_init(void)
 {
+	static bool badge_sdcard_init_done = false;
+
+	if (badge_sdcard_init_done)
+		return;
+
 	// configure charge-stat pin
 #ifdef PORTEXP_PIN_NUM_SD_CD
 	badge_portexp_set_io_direction(PORTEXP_PIN_NUM_SD_CD, 0);
@@ -35,4 +40,6 @@ badge_sdcard_init(void)
 #elif defined(MPR121_PIN_NUM_SD_CD)
 	badge_mpr121_configure_gpio(MPR121_PIN_NUM_SD_CD, MPR121_INPUT);
 #endif
+
+	badge_sdcard_init_done = true;
 }

--- a/components/badge/badge_touch.c
+++ b/components/badge/badge_touch.c
@@ -61,12 +61,19 @@ badge_touch_intr_handler(void *arg)
 void
 badge_touch_init(void)
 {
+	static bool badge_touch_init_done = false;
+
+	if (badge_touch_init_done)
+		return;
+
 	badge_portexp_set_input_default_state(PORTEXP_PIN_NUM_TOUCH, 1);
 	badge_portexp_set_interrupt_enable(PORTEXP_PIN_NUM_TOUCH, 1);
 	badge_portexp_set_interrupt_handler(PORTEXP_PIN_NUM_TOUCH, badge_touch_intr_handler, NULL);
 
 	// read pending old events
 	badge_touch_intr_handler(NULL);
+
+	badge_touch_init_done = true;
 }
 
 void

--- a/components/badge/badge_vibrator.c
+++ b/components/badge/badge_vibrator.c
@@ -57,6 +57,11 @@ badge_vibrator_activate(uint32_t pattern)
 void
 badge_vibrator_init(void)
 {
+	static bool badge_vibrator_init_done = false;
+
+	if (badge_vibrator_init_done)
+		return;
+
 	// configure vibrator pin
 #ifdef PORTEXP_PIN_NUM_VIBRATOR
 	badge_portexp_set_output_state(PORTEXP_PIN_NUM_VIBRATOR, 0);
@@ -65,6 +70,8 @@ badge_vibrator_init(void)
 #elif defined(MPR121_PIN_NUM_VIBRATOR)
 	badge_mpr121_configure_gpio(MPR121_PIN_NUM_VIBRATOR, MPR121_OUTPUT);
 #endif
+
+	badge_vibrator_init_done = true;
 }
 
 #endif // defined(PORTEXP_PIN_NUM_VIBRATOR) || defined(MPR121_PIN_NUM_VIBRATOR)


### PR DESCRIPTION
Add boolean flag to every *_init() method to avoid double initialization.

(and initialize gpio_config_t io_conf as struct instead of per field)