### PR TITLE
Update badge-i2c code to support reading multiple values.

### DIFF
--- a/components/badge/badge_i2c.h
+++ b/components/badge/badge_i2c.h
@@ -9,7 +9,7 @@
 extern void badge_i2c_init(void);
 
 /** read register via i2c bus */
-extern esp_err_t badge_i2c_read_reg(uint8_t addr, uint8_t reg, uint8_t *value);
+extern esp_err_t badge_i2c_read_reg(uint8_t addr, uint8_t reg, uint8_t *value, size_t value_len);
 
 /** write to register via i2c bus */
 extern esp_err_t badge_i2c_write_reg(uint8_t addr, uint8_t reg, uint8_t value);

--- a/components/badge/badge_mpr121.h
+++ b/components/badge/badge_mpr121.h
@@ -48,14 +48,6 @@ extern void badge_mpr121_set_interrupt_handler(uint8_t pin, badge_mpr121_intr_t 
 extern int badge_mpr121_get_interrupt_status(void);
 
 /**
- * Retrieve mpr121 internal state (for the mpr121 demo)
- * @param data pointer to uint32_t data[32] data structure.
- * @return 0 on success; -1 on error
- * @deprecated use badge_mpr121_get_touch_info() instead.
- */
-extern int badge_mpr121_get_electrode_data(uint32_t *data) __attribute__((deprecated));
-
-/**
  * Retrieve mpr121 touch info
  * @param info touch info will be written to this structure.
  * @return 0 on success; -1 on error

--- a/components/badge/badge_portexp.c
+++ b/components/badge/badge_portexp.c
@@ -47,7 +47,7 @@ static inline int
 badge_portexp_read_reg(uint8_t reg)
 {
 	uint8_t value;
-	esp_err_t ret = badge_i2c_read_reg(I2C_PORTEXP_ADDR, reg, &value);
+	esp_err_t ret = badge_i2c_read_reg(I2C_PORTEXP_ADDR, reg, &value, 1);
 
 	if (ret == ESP_OK) {
 #ifdef CONFIG_SHA_BADGE_PORTEXP_DEBUG


### PR DESCRIPTION
- update mpr121 driver to make use of this.
- remove deprecated badge_mpr121_get_electrode_data method.