### PR TITLE
use 8 bit greyscale backend buffer for ugfx

### DIFF
--- a/components/badge/badge_eink.c
+++ b/components/badge/badge_eink.c
@@ -190,7 +190,7 @@ badge_eink_display_one_layer(const uint8_t *img, int flags)
 		(flags >> DISPLAY_FLAG_LUT_BIT) & ((1 << DISPLAY_FLAG_LUT_SIZE)-1);
 
 	uint8_t *buf = badge_eink_tmpbuf;
-	badge_eink_create_bitplane(img, buf, 0, flags);
+	badge_eink_create_bitplane(img, buf, 0x80, flags);
 
 	if ((flags & DISPLAY_FLAG_NO_UPDATE) != 0)
 	{

--- a/components/badge/badge_eink.h
+++ b/components/badge/badge_eink.h
@@ -65,6 +65,7 @@ extern void badge_eink_update(const struct badge_eink_update *upd_conf);
 #define DISPLAY_FLAG_LUT_SIZE   4
 #define DISPLAY_FLAG_LUT(x) ((1+(x)) << DISPLAY_FLAG_LUT_BIT)
 
+extern void badge_eink_display_one_layer(const uint8_t *img, int flags);
 /*
  * display image on badge
  *

--- a/components/ugfx/board_framebuffer.h
+++ b/components/ugfx/board_framebuffer.h
@@ -15,7 +15,7 @@
 
 // Set this to your frame buffer pixel format.
 #ifndef GDISP_LLD_PIXELFORMAT
-	#define GDISP_LLD_PIXELFORMAT		GDISP_PIXELFORMAT_MONO
+	#define GDISP_LLD_PIXELFORMAT		GDISP_PIXELFORMAT_GRAY256
 #endif
 
 // Uncomment this if your frame buffer device requires flushing
@@ -23,8 +23,7 @@
 
 // For now we simply keep the current state of the framebuffer in memory, and
 // encode it and send it to the badge_eink driver on flush
-uint8_t* framebuffer;
-uint8_t* target_buffer;
+uint8_t * ugfx_framebuffer;
 uint8_t target_lut;
 
 #ifdef GDISP_DRIVER_VMT
@@ -33,8 +32,7 @@ uint8_t target_lut;
 		badge_eink_init();
 
 		// Careful: this is never freed, so don't initialize the board multiple times!
-		framebuffer = malloc(BADGE_EINK_WIDTH * BADGE_EINK_HEIGHT);
-		target_buffer = malloc(BADGE_EINK_WIDTH * BADGE_EINK_HEIGHT / 8);
+		ugfx_framebuffer = malloc(BADGE_EINK_WIDTH * BADGE_EINK_HEIGHT);
 
 //	        ets_printf("Initializing eink ugfx driver!\n");
 //		ets_printf("sizeof(COLOR_TYPE): %d", sizeof(COLOR_TYPE));
@@ -44,7 +42,7 @@ uint8_t target_lut;
 		g->g.Backlight = 100;
 		g->g.Contrast = 50;
 		fbi->linelen = g->g.Width;
-		fbi->pixels = framebuffer;
+		fbi->pixels = ugfx_framebuffer;
 		target_lut = 3;
 	}
 
@@ -52,22 +50,11 @@ uint8_t target_lut;
 		static void board_flush(GDisplay *g) {
 			(void) g;
 //			ets_printf("Flushing framebuffer!\n");
-//			ets_printf("First byte: %d\n", framebuffer[0]);
-			for (int i = 0; i < BADGE_EINK_WIDTH * BADGE_EINK_HEIGHT / 8; i++) {
-				target_buffer[i] =
-					framebuffer[i * 8 + 7] << 7 |
-					framebuffer[i * 8 + 6] << 6 |
-					framebuffer[i * 8 + 5] << 5 |
-					framebuffer[i * 8 + 4] << 4 |
-					framebuffer[i * 8 + 3] << 3 |
-					framebuffer[i * 8 + 2] << 2 |
-					framebuffer[i * 8 + 1] << 1 |
-					framebuffer[i * 8];
-			}
+//			ets_printf("First byte: %d\n", ugfx_framebuffer[0]);
 			if (target_lut == 0)
-				badge_eink_display(target_buffer, 0);
+				badge_eink_display_one_layer(ugfx_framebuffer, DISPLAY_FLAG_GREYSCALE);
 			else
-				badge_eink_display(target_buffer, DISPLAY_FLAG_LUT(target_lut - 1));
+				badge_eink_display_one_layer(ugfx_framebuffer, DISPLAY_FLAG_LUT(target_lut - 1) | DISPLAY_FLAG_GREYSCALE);
 //			ets_printf("Flushed framebuffer!\n");
 		}
 	#endif


### PR DESCRIPTION
00:58 <@tsd> bas-ugfx branch now has a 8 bit greyscale backend for ugfx
00:58 <@tsd> ugfx demo in the c firmware still works
01:00 <@tsd> now you can load a png-image directly into ugfx's fbi->pixels

The switch between black and white is somewhere around greyscale value 0xb8.