### PR TITLE
fix badge_eink_dev_reset() return type.

### DIFF
--- a/components/badge/badge_eink_dev.c
+++ b/components/badge/badge_eink_dev.c
@@ -243,8 +243,9 @@ badge_eink_dev_write_byte(uint8_t data)
 #else
 
 // add dummy functions
-void
+esp_err_t
 badge_eink_dev_reset(void) {
+	return ESP_OK;
 }
 
 bool


### PR DESCRIPTION
return-type was changed in the big error-checking commit.