### PR TITLE
Make vbat on firstrun a warning

### DIFF
--- a/components/badge-first-run/badge_first_run.c
+++ b/components/badge-first-run/badge_first_run.c
@@ -515,8 +515,8 @@ badge_first_run(void)
 	sprintf(line, "Vbat = %u.%03u V", pwr_vbat/1000, pwr_vbat % 1000);
 	disp_line(line, 0);
 	if (pwr_vbat > 100) {
-		disp_line("Error: Did not expect any power on Vbat.",FONT_MONOSPACE);
-		return;
+		disp_line("WARNING: Did not expect any power on Vbat.",FONT_MONOSPACE);
+		vTaskDelay(2000 / portTICK_PERIOD_MS);
 	}
 
 	disp_line("Vusb = ...",NO_NEWLINE);


### PR DESCRIPTION
The battery connector is sometime a b*tch... Now you can leave the battery in :)