### PR TITLE
move badge_eink_{tmp,old}buf to iram and save 9.2 KB of main memory.

### DIFF
--- a/components/badge/badge_eink_dev.h
+++ b/components/badge/badge_eink_dev.h
@@ -74,4 +74,22 @@ static inline void badge_eink_dev_write_command_stream(uint8_t command, const ui
 	badge_eink_dev_write_command_end();
 }
 
+static inline void badge_eink_dev_write_byte_u32(uint32_t data)
+{
+	badge_eink_dev_write_byte(data >> 24);
+	badge_eink_dev_write_byte(data >> 16);
+	badge_eink_dev_write_byte(data >> 8);
+	badge_eink_dev_write_byte(data);
+}
+
+static inline void badge_eink_dev_write_command_stream_u32(uint8_t command, const uint32_t *data,
+                                         unsigned int datalen)
+{
+	badge_eink_dev_write_command_init(command);
+	while (datalen-- > 0) {
+		badge_eink_dev_write_byte_u32(*(data++));
+	}
+	badge_eink_dev_write_command_end();
+}
+
 #endif // BADGE_EINK_DEV_H


### PR DESCRIPTION
tested and works here.

.. but it might not be a good idea to put it in today's release