### PR TITLE
remove deprecated unused method badge_leds_set_state()

### DIFF
--- a/components/badge/badge_leds.c
+++ b/components/badge/badge_leds.c
@@ -165,36 +165,6 @@ badge_leds_send_data(uint8_t *data, int len)
 }
 
 esp_err_t
-badge_leds_set_state(uint8_t *rgbw)
-{
-	uint8_t buf[6*4];
-
-	int pos=0;
-	bool all_zero = true;
-	int i;
-	for (i=5; i>=0; i--)
-	{
-		int r = rgbw[i*4+0];
-		int g = rgbw[i*4+1];
-		int b = rgbw[i*4+2];
-		int w = rgbw[i*4+3];
-		buf[pos++] = g;
-		buf[pos++] = r;
-		buf[pos++] = b;
-		buf[pos++] = w;
-		if (r|g|b|w)
-			all_zero = false;
-	}
-
-	if (all_zero)
-	{
-		return badge_leds_disable();
-	}
-
-	return badge_leds_send_data(buf, sizeof(buf));
-}
-
-esp_err_t
 badge_leds_init(void)
 {
 	static bool badge_leds_init_done = false;

--- a/components/badge/badge_leds.h
+++ b/components/badge/badge_leds.h
@@ -24,15 +24,6 @@ extern esp_err_t badge_leds_enable(void);
 extern esp_err_t badge_leds_disable(void);
 
 /**
- * Configure the 6 on-board leds with the given rgbw data.
- * @param rgbw array with red, green, blue and white data for every
- *   led. First index is the left led.
- * @return ESP_OK on success; any other value indicates an error
- * @deprecated use badge_leds_send_data() instead.
- */
-extern esp_err_t badge_leds_set_state(uint8_t *rgbw) __attribute__((deprecated));
-
-/**
  * Send color-data to the leds bus.
  * @param data the data-bytes to send on the bus.
  * @param len the data-length.


### PR DESCRIPTION
Not to be confused with the micropython method 'badge.leds_set_state()', which is a wrapper around badge.leds_send_data()'.

