### PR TITLE
use ESP_LOGx() where possible.

### DIFF
--- a/components/badge-first-run/badge_first_run.c
+++ b/components/badge-first-run/badge_first_run.c
@@ -713,7 +713,7 @@ badge_check_first_run(void)
 	}
 
 	uint8_t buf[64];
-	ESP_LOGD(TAG, "nvs partition address: 0x%x\n", nvs_partition->address);
+	ESP_LOGD(TAG, "nvs partition address: 0x%x", nvs_partition->address);
 	int res = spi_flash_read(nvs_partition->address, buf, sizeof(buf));
 	if (res != ESP_OK)
 	{

--- a/components/badge/badge_eink_dev.c
+++ b/components/badge/badge_eink_dev.c
@@ -1,5 +1,9 @@
 #include <sdkconfig.h>
 
+#ifdef CONFIG_SHA_BADGE_EINK_DEBUG
+#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
+#endif // CONFIG_SHA_BADGE_EINK_DEBUG
+
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -74,16 +78,14 @@ badge_eink_dev_busy_wait(void)
 
 void
 badge_eink_dev_intr_handler(void *arg)
-{
+{ /* in interrupt handler */
 	int gpio_state = gpio_get_level(PIN_NUM_EPD_BUSY);
+
 #ifdef CONFIG_SHA_BADGE_EINK_DEBUG
 	static int gpio_last_state = -1;
-	if (gpio_last_state != gpio_state)
+	if (gpio_state != -1 && gpio_last_state != gpio_state)
 	{
-		if (gpio_state == 1)
-			ets_printf("badge_eink_dev: EPD-Busy Int down\n");
-		else if (gpio_state == 0)
-			ets_printf("badge_eink_dev: EPD-Busy Int up\n");
+		ets_printf("badge_eink_dev: EPD-Busy Int %s\n", gpio_state == 0 ? "up" : "down");
 	}
 	gpio_last_state = gpio_state;
 #endif // CONFIG_SHA_BADGE_EINK_DEBUG

--- a/components/badge/badge_eink_lut.c
+++ b/components/badge/badge_eink_lut.c
@@ -1,9 +1,13 @@
 #include <sdkconfig.h>
 
+#ifdef CONFIG_SHA_BADGE_EINK_LUT_DEBUG
+#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
+#endif // CONFIG_SHA_BADGE_EINK_LUT_DEBUG
+
 #include <stdint.h>
 #include <string.h>
+#include <stdio.h>
 
-#include <rom/ets_sys.h>
 #include <esp_log.h>
 
 #include "badge_eink_lut.h"
@@ -86,9 +90,8 @@ uint8_t *
 badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags)
 {
 	static uint8_t lut[30];
-#ifdef CONFIG_SHA_BADGE_EINK_LUT_DEBUG
-	ets_printf("badge_eink_lut_generate: flags = %d.\n", flags);
-#endif // CONFIG_SHA_BADGE_EINK_LUT_DEBUG
+
+	ESP_LOGD(TAG, "badge_eink_lut_generate: flags = %d.", flags);
 
 	memset(lut, 0, sizeof(lut));
 
@@ -102,7 +105,7 @@ badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink
 			int plen = len > 15 ? 15 : len;
 			if (pos == 20)
 			{
-				ets_printf("badge_eink_lut_generate: lut overflow.\n");
+				ESP_LOGE(TAG, "badge_eink_lut_generate: lut overflow.");
 				return NULL; // full
 			}
 			lut[pos] = voltages;
@@ -120,7 +123,7 @@ badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink
 	// the GDEH029A01 needs an empty update cycle at the end.
 	if (pos == 20)
 	{
-		ets_printf("badge_eink_lut_generate: lut overflow.\n");
+		ESP_LOGE(TAG, "badge_eink_lut_generate: lut overflow.");
 		return NULL; // full
 	}
 	if ((pos & 1) == 0)
@@ -129,13 +132,21 @@ badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink
 		lut[20+(pos >> 1)] |= 1 << 4;
 
 #ifdef CONFIG_SHA_BADGE_EINK_LUT_DEBUG
-	ets_printf("badge_eink_lut_generate: dump.\n");
-	int i;
-	for (i=0; i<30; i++)
 	{
-		ets_printf(" %02x", lut[i]);
-		if ((i % 10) == 9)
-			ets_printf("\n");
+		ESP_LOGD(TAG, "badge_eink_lut_generate: dump.");
+		char line[10*3 + 1];
+		char *lptr = line;
+		int i;
+		for (i=0; i<30; i++)
+		{
+			sprintf(lptr, " %02x", lut[i]);
+			lptr = &lptr[3];
+			if ((i % 10) == 9)
+			{
+				ESP_LOGD(TAG, "%s", line);
+				lptr = line;
+			}
+		}
 	}
 #endif // CONFIG_SHA_BADGE_EINK_LUT_DEBUG
 
@@ -149,9 +160,8 @@ uint8_t *
 badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags)
 {
 	static uint8_t lut[70];
-#ifdef CONFIG_SHA_BADGE_EINK_LUT_DEBUG
-	ets_printf("badge_eink_lut_generate: flags = %d.\n", flags);
-#endif // CONFIG_SHA_BADGE_EINK_LUT_DEBUG
+
+	ESP_LOGD(TAG, "badge_eink_lut_generate: flags = %d.", flags);
 
 	memset(lut, 0, sizeof(lut));
 
@@ -162,7 +172,7 @@ badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink
 		int len = list->length;
 		if (pos == 7)
 		{
-			ets_printf("badge_eink_lut_generate: lut overflow.\n");
+			ESP_LOGE(TAG, "badge_eink_lut_generate: lut overflow.");
 			return NULL; // full
 		}
 		uint8_t voltages = badge_eink_lut_conv(list->voltages, flags);
@@ -185,19 +195,31 @@ badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink
 	}
 
 #ifdef CONFIG_SHA_BADGE_EINK_LUT_DEBUG
-	ets_printf("badge_eink_lut_generate: dump.\n");
-	int i;
-	for (i=0; i<35; i++)
 	{
-		ets_printf(" %02x", lut[i]);
-		if ((i % 7) == 6)
-			ets_printf("\n");
-	}
-	for (; i<70; i++)
-	{
-		ets_printf(" %02x", lut[i]);
-		if ((i % 5) == 4)
-			ets_printf("\n");
+		ESP_LOGD(TAG, "badge_eink_lut_generate: dump.");
+		char line[3*7+1];
+		char *lptr = line;
+		int i;
+		for (i=0; i<35; i++)
+		{
+			sprintf(lptr, " %02x", lut[i]);
+			lptr = &lptr[3];
+			if ((i % 7) == 6)
+			{
+				ESP_LOGD(TAG, "%s", line);
+				lptr = line;
+			}
+		}
+		for (; i<70; i++)
+		{
+			sprintf(lptr, " %02x", lut[i]);
+			lptr = &lptr[3];
+			if ((i % 5) == 4)
+			{
+				ESP_LOGD(TAG, "%s", line);
+				lptr = line;
+			}
+		}
 	}
 #endif // CONFIG_SHA_BADGE_EINK_LUT_DEBUG
 

--- a/components/badge/badge_gpiobutton.c
+++ b/components/badge/badge_gpiobutton.c
@@ -14,7 +14,7 @@ int badge_gpiobutton_old_state[40] = { 0 };
 
 void
 badge_gpiobutton_handler(void *arg)
-{
+{ /* in interrupt handler */
 	uint32_t gpio_num = (uint32_t) arg;
 
 	int new_state = gpio_get_level(gpio_num);

--- a/components/badge/badge_i2c.c
+++ b/components/badge/badge_i2c.c
@@ -5,7 +5,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <rom/ets_sys.h>
 #include <esp_log.h>
 #include <driver/i2c.h>
 
@@ -108,7 +107,7 @@ badge_i2c_read_reg(uint8_t addr, uint8_t reg, uint8_t *value, size_t value_len)
 
 	if (xSemaphoreGive(badge_i2c_mux) != pdTRUE)
 	{
-		ets_printf("badge_i2c: xSemaphoreGive() did not return pdTRUE.\n");
+		ESP_LOGE(TAG, "xSemaphoreGive() did not return pdTRUE.");
 	}
 
 	return res;
@@ -139,7 +138,7 @@ badge_i2c_write_reg(uint8_t addr, uint8_t reg, uint8_t value)
 
 	if (xSemaphoreGive(badge_i2c_mux) != pdTRUE)
 	{
-		ets_printf("badge_i2c: xSemaphoreGive() did not return pdTRUE.\n");
+		ESP_LOGE(TAG, "xSemaphoreGive() did not return pdTRUE.");
 	}
 
 	return res;
@@ -170,7 +169,7 @@ badge_i2c_read_event(uint8_t addr, uint8_t *buf)
 
 	if (xSemaphoreGive(badge_i2c_mux) != pdTRUE)
 	{
-		ets_printf("badge_i2c: xSemaphoreGive() did not return pdTRUE.\n");
+		ESP_LOGE(TAG, "xSemaphoreGive() did not return pdTRUE.");
 	}
 
 	return res;

--- a/components/badge/badge_input.c
+++ b/components/badge/badge_input.c
@@ -1,5 +1,9 @@
 #include <sdkconfig.h>
 
+#ifdef CONFIG_SHA_BADGE_INPUT_DEBUG
+#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
+#endif // CONFIG_SHA_BADGE_INPUT_DEBUG
+
 #include <esp_event.h>
 #include <esp_log.h>
 
@@ -32,25 +36,29 @@ badge_input_init(void)
 	return ESP_OK;
 }
 
+static const char *badge_input_button_name[11] = {
+	"(null)",
+	"UP",
+	"DOWN",
+	"LEFT",
+	"RIGHT",
+	"(null)",
+	"A",
+	"B",
+	"SELECT",
+	"START",
+	"FLASH",
+};
+
 void
 badge_input_add_event(uint32_t button_id, bool pressed, bool in_isr)
-{
+{ /* maybe in interrupt handler */
 #ifdef CONFIG_SHA_BADGE_INPUT_DEBUG
-	const char *button_name[11] = {
-		"(null)",
-		"UP",
-		"DOWN",
-		"LEFT",
-		"RIGHT",
-		"(null)",
-		"A",
-		"B",
-		"SELECT",
-		"START",
-		"FLASH",
-	};
-	ets_printf("badge_input: Button %s %s.\n", button_name[button_id < 11 ? button_id : 0], pressed ? "pressed" : "released");
+	ets_printf("badge_input: Button %s %s.\n",
+			badge_input_button_name[button_id < 11 ? button_id : 0],
+			pressed ? "pressed" : "released");
 #endif // CONFIG_SHA_BADGE_INPUT_DEBUG
+
 	if (pressed)
 	{
 		badge_input_button_state |= 1 << button_id;

--- a/components/badge/badge_leds.c
+++ b/components/badge/badge_leds.c
@@ -5,7 +5,6 @@
 #include <stdio.h>
 #include <string.h>
 
-#include <rom/ets_sys.h>
 #include <freertos/FreeRTOS.h>
 #include <freertos/task.h>
 #include <esp_err.h>

--- a/components/badge/badge_power.c
+++ b/components/badge/badge_power.c
@@ -1,11 +1,14 @@
 #include <sdkconfig.h>
 
+#ifdef CONFIG_SHA_BADGE_POWER_DEBUG
+#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
+#endif // CONFIG_SHA_BADGE_POWER_DEBUG
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#include <rom/ets_sys.h>
 #include <esp_log.h>
 #include <driver/adc.h>
 #include <driver/gpio.h>
@@ -63,9 +66,7 @@ static int badge_power_leds_sdcard = 0; // bit 0 = leds, bit 1 = sd-card
 static esp_err_t
 badge_power_sdcard_leds_enable(void)
 {
-#ifdef CONFIG_SHA_BADGE_POWER_DEBUG
-	ets_printf("badge_power: enabling power to sdcard and leds.\n");
-#endif // CONFIG_SHA_BADGE_POWER_DEBUG
+	ESP_LOGD(TAG, "enabling power to sdcard and leds.");
 
 	esp_err_t ret;
 #ifdef PORTEXP_PIN_NUM_LEDS
@@ -76,10 +77,10 @@ badge_power_sdcard_leds_enable(void)
 	ret = ESP_OK;
 #endif
 
-#ifdef CONFIG_SHA_BADGE_POWER_DEBUG
 	if (ret != ESP_OK)
-		ets_printf("badge_power: failed to enable power.\n");
-#endif // CONFIG_SHA_BADGE_POWER_DEBUG
+	{
+		ESP_LOGW(TAG, "failed to enable power.");
+	}
 
 	return ret;
 }
@@ -113,9 +114,7 @@ badge_power_sdcard_leds_disable(void)
 		return res;
 #endif // PIN_NUM_SD_CLK
 
-#ifdef CONFIG_SHA_BADGE_POWER_DEBUG
-	ets_printf("badge_power: disabling power to sdcard and leds.\n");
-#endif // CONFIG_SHA_BADGE_POWER_DEBUG
+	ESP_LOGD(TAG, "disabling power to sdcard and leds.");
 
 	int ret;
 #ifdef PORTEXP_PIN_NUM_LEDS
@@ -126,10 +125,10 @@ badge_power_sdcard_leds_disable(void)
 	ret = ESP_OK;
 #endif
 
-#ifdef CONFIG_SHA_BADGE_POWER_DEBUG
 	if (ret != ESP_OK)
-		ets_printf("badge_power: failed to disable power.\n");
-#endif // CONFIG_SHA_BADGE_POWER_DEBUG
+	{
+		ESP_LOGW(TAG, "failed to disable power.");
+	}
 
 	return ret;
 }
@@ -225,9 +224,6 @@ badge_power_init(void)
 	ESP_LOGD(TAG, "init called");
 
 	esp_err_t res;
-#ifdef CONFIG_SHA_BADGE_POWER_DEBUG
-	ets_printf("badge_power: initializing.\n");
-#endif // CONFIG_SHA_BADGE_POWER_DEBUG
 
 	// configure adc width
 #if defined(ADC1_CHAN_VBAT_SENSE) || defined(ADC1_CHAN_VUSB_SENSE)

--- a/components/badge/badge_touch.c
+++ b/components/badge/badge_touch.c
@@ -1,11 +1,14 @@
 #include <sdkconfig.h>
 
+#ifdef CONFIG_SHA_BADGE_TOUCH_DEBUG
+#define LOG_LOCAL_LEVEL ESP_LOG_DEBUG
+#endif // CONFIG_SHA_BADGE_TOUCH_DEBUG
+
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
-#include <rom/ets_sys.h>
 #include <esp_log.h>
 
 #include <badge_pins.h>
@@ -26,12 +29,10 @@ badge_touch_read_event(void)
 	esp_err_t ret = badge_i2c_read_event(I2C_TOUCHPAD_ADDR, buf);
 
 	if (ret == ESP_OK) {
-#ifdef CONFIG_SHA_BADGE_TOUCH_DEBUG
-		ets_printf("badge_touch: event: 0x%02x, 0x%02x, 0x%02x\n", buf[0], buf[1], buf[2]);
-#endif // CONFIG_SHA_BADGE_TOUCH_DEBUG
+		ESP_LOGD(TAG, "event: 0x%02x, 0x%02x, 0x%02x", buf[0], buf[1], buf[2]);
 		return (buf[0] << 16) | (buf[1] << 8) | (buf[2]);
 	} else {
-		ets_printf("badge_touch: i2c master read: error %d\n", ret);
+		ESP_LOGE(TAG, "i2c master read: error %d", ret);
 		return -1;
 	}
 }


### PR DESCRIPTION
The ESP_LOGx() methods are unfortunately not allowed in the
interrupt handlers. We still have to use the ets_printf() there.