### PR TITLE
Add raw screen buffer to badge_eink_update() call.

### DIFF
--- a/components/badge/badge_eink.h
+++ b/components/badge/badge_eink.h
@@ -50,9 +50,10 @@ struct badge_eink_update {
 extern const struct badge_eink_update eink_upd_default;
 
 /** refresh the eink display with given config-settings
+ * @param buf the raw buffer to write to the screen
  * @param upd_conf the config-settings to use
  */
-extern void badge_eink_update(const struct badge_eink_update *upd_conf);
+extern void badge_eink_update(const uint32_t *buf, const struct badge_eink_update *upd_conf);
 
 /* badge_eink_display 'mode' settings */
 // bitmapped flags:

--- a/main/demo_dot1.c
+++ b/main/demo_dot1.c
@@ -1,24 +1,18 @@
 #include "sdkconfig.h"
 
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
+#include <string.h>
+
 #include <badge_input.h>
 #include <badge_eink_dev.h>
 #include <badge_eink_lut.h>
+#include <badge_eink_fb.h>
 #include <badge_eink.h>
 
 void demoDot1(void) {
+  uint32_t *tmpbuf = (uint32_t *) badge_eink_fb;
+
   /* clear screen */
-  badge_eink_set_ram_area(0, DISP_SIZE_X_B - 1, 0, DISP_SIZE_Y - 1);
-  badge_eink_set_ram_pointer(0, 0);
-  badge_eink_dev_write_command_init(0x24);
-  {
-    int x, y;
-    for (y = 0; y < DISP_SIZE_Y; y++) {
-      for (x = 0; x < 16; x++)
-        badge_eink_dev_write_byte(0xff);
-    }
-  }
-  badge_eink_dev_write_command_end();
+  memset(tmpbuf, 0xff, DISP_SIZE_X_B * DISP_SIZE_Y);
 
   struct badge_eink_update eink_upd = {
     .lut      = BADGE_EINK_LUT_DEFAULT,
@@ -27,12 +21,12 @@ void demoDot1(void) {
     .y_start  = 0,
     .y_end    = 295,
   };
-  badge_eink_update(&eink_upd);
+  badge_eink_update(tmpbuf, &eink_upd);
 
   // init LUT
   struct badge_eink_lut_entry lut[] = {
-	  { .length = 1, .voltages = 0x99, },
-	  { .length = 0 }
+    { .length = 1, .voltages = 0x99, },
+    { .length = 0 }
   };
 
   int px = 100;
@@ -46,8 +40,8 @@ void demoDot1(void) {
   int dot_pos = 0;
 
   while (1) {
-	if (badge_input_get_event(10) != 0)
-	  return;
+    if (badge_input_get_event(10) != 0)
+      return;
 
     /* update dot */
     if (px + xd < 0)
@@ -68,24 +62,13 @@ void demoDot1(void) {
       dot_pos = 0;
 
     /* clear screen */
-    badge_eink_set_ram_area(0, DISP_SIZE_X_B - 1, 0, DISP_SIZE_Y - 1);
-    badge_eink_set_ram_pointer(0, 0);
-    badge_eink_dev_write_command_init(0x24);
-    {
-      int x, y;
-      for (y = 0; y < DISP_SIZE_Y; y++) {
-        for (x = 0; x < 16; x++)
-          badge_eink_dev_write_byte(0xff);
-      }
-    }
-    badge_eink_dev_write_command_end();
+    memset(tmpbuf, 0xff, DISP_SIZE_X_B * DISP_SIZE_Y);
 
     int i;
     for (i = 0; i < 16; i++) {
       int px = dots[i] & 127;
       int py = dots[i] >> 7;
-      badge_eink_set_ram_pointer(px >> 3, py);
-      badge_eink_dev_write_command_p1(0x24, 0xff ^ (128 >> (px & 7)));
+      tmpbuf[(px >> 5) + py*4] &= ~( 0x80000000 >> (px & 31) );
     }
 
     struct badge_eink_update eink_upd = {
@@ -96,8 +79,6 @@ void demoDot1(void) {
       .y_start  = 0,
       .y_end    = 295,
     };
-    badge_eink_update(&eink_upd);
+    badge_eink_update(tmpbuf, &eink_upd);
   }
 }
-
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1

--- a/main/demo_dot1.h
+++ b/main/demo_dot1.h
@@ -1,10 +1,6 @@
 #ifndef DEMO_DOT1_H
 #define DEMO_DOT1_H
 
-#include "sdkconfig.h"
-
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 extern void demoDot1(void);
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1
 
 #endif // DEMO_DOT1_H

--- a/main/demo_greyscale1.c
+++ b/main/demo_greyscale1.c
@@ -1,27 +1,28 @@
 #include "sdkconfig.h"
 
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
+#include <string.h>
+
 #include <esp_event.h>
 
 #include <badge_input.h>
 #include <badge_eink.h>
 #include <badge_eink_dev.h>
+#include <badge_eink_fb.h>
 
 void demoGreyscale1(void) {
+  uint32_t *tmpbuf = (uint32_t *) badge_eink_fb;
+
   int i;
   for (i = 0; i < 2; i++) {
     /* draw test pattern */
-    badge_eink_set_ram_area(0, DISP_SIZE_X_B - 1, 0, DISP_SIZE_Y - 1);
-    badge_eink_set_ram_pointer(0, 0);
-    badge_eink_dev_write_command_init(0x24);
     {
+      uint32_t *dptr = tmpbuf;
       int x, y;
       for (y = 0; y < DISP_SIZE_Y; y++) {
-        for (x = 0; x < 16; x++)
-          badge_eink_dev_write_byte(x & 4 ? 0xff : 0x00);
+        for (x = 0; x < 4; x++)
+          *dptr++ = (x & 1) ? 0xffffffff : 0x00000000;
       }
     }
-    badge_eink_dev_write_command_end();
 
     struct badge_eink_update eink_upd = {
       .lut      = BADGE_EINK_LUT_DEFAULT,
@@ -30,24 +31,21 @@ void demoGreyscale1(void) {
       .y_start  = 0,
       .y_end    = 295,
     };
-    badge_eink_update(&eink_upd);
+    badge_eink_update(tmpbuf, &eink_upd);
   }
 
   int y = 0;
   int n = 8;
   while (y < DISP_SIZE_Y) {
     /* draw new test pattern */
-    badge_eink_set_ram_area(0, DISP_SIZE_X_B - 1, 0, DISP_SIZE_Y - 1);
-    badge_eink_set_ram_pointer(0, 0);
-    badge_eink_dev_write_command_init(0x24);
     {
+      uint32_t *dptr = tmpbuf;
       int x, y;
       for (y = 0; y < DISP_SIZE_Y; y++) {
-        for (x = 0; x < 16; x++)
-          badge_eink_dev_write_byte(x & 2 ? 0xff : 0x00);
+        for (x = 0; x < 4; x++)
+          *dptr++ = 0xffff0000;
       }
     }
-    badge_eink_dev_write_command_end();
 
     if (y + n > DISP_SIZE_Y)
       n = DISP_SIZE_Y - y;
@@ -59,7 +57,7 @@ void demoGreyscale1(void) {
       .y_start  = y,
       .y_end    = y+n,
     };
-    badge_eink_update(&eink_upd);
+    badge_eink_update(tmpbuf, &eink_upd);
 
     vTaskDelay(1000 / portTICK_PERIOD_MS);
     y += n;
@@ -69,17 +67,14 @@ void demoGreyscale1(void) {
   n = 4;
   while (y < DISP_SIZE_Y) {
     /* draw new test pattern */
-    badge_eink_set_ram_area(0, DISP_SIZE_X_B - 1, 0, DISP_SIZE_Y - 1);
-    badge_eink_set_ram_pointer(0, 0);
-    badge_eink_dev_write_command_init(0x24);
     {
+      uint32_t *dptr = tmpbuf;
       int x, y;
       for (y = 0; y < DISP_SIZE_Y; y++) {
-        for (x = 0; x < 16; x++)
-          badge_eink_dev_write_byte(x & 8 ? 0xff : 0x00);
+        for (x = 0; x < 4; x++)
+          *dptr++ = (x & 2) ? 0xffffffff : 0x00000000;
       }
     }
-    badge_eink_dev_write_command_end();
 
     if (y + n > DISP_SIZE_Y)
       n = DISP_SIZE_Y - y;
@@ -91,7 +86,7 @@ void demoGreyscale1(void) {
       .y_start  = y,
       .y_end    = y+n,
     };
-    badge_eink_update(&eink_upd);
+    badge_eink_update(tmpbuf, &eink_upd);
 
     vTaskDelay(1000 / portTICK_PERIOD_MS);
     y += n;
@@ -101,5 +96,3 @@ void demoGreyscale1(void) {
   // wait for random keypress
   badge_input_get_event(-1);
 }
-
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1

--- a/main/demo_greyscale1.h
+++ b/main/demo_greyscale1.h
@@ -1,10 +1,6 @@
 #ifndef DEMO_GREYSCALE1_H
 #define DEMO_GREYSCALE1_H
 
-#include "sdkconfig.h"
-
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 extern void demoGreyscale1(void);
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1
 
 #endif // DEMO_GREYSCALE1_H

--- a/main/demo_greyscale2.h
+++ b/main/demo_greyscale2.h
@@ -1,10 +1,6 @@
 #ifndef DEMO_GREYSCALE2_H
 #define DEMO_GREYSCALE2_H
 
-#include "sdkconfig.h"
-
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 extern void demoGreyscale2(void);
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1
 
 #endif // DEMO_GREYSCALE2_H

--- a/main/demo_greyscale_img1.h
+++ b/main/demo_greyscale_img1.h
@@ -1,10 +1,6 @@
 #ifndef DEMO_GREYSCALE_IMG1_H
 #define DEMO_GREYSCALE_IMG1_H
 
-#include "sdkconfig.h"
-
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 extern void demoGreyscaleImg1(void);
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1
 
 #endif // DEMO_GREYSCALE_IMG1_H

--- a/main/demo_greyscale_img2.h
+++ b/main/demo_greyscale_img2.h
@@ -1,10 +1,6 @@
 #ifndef DEMO_GREYSCALE_IMG2_H
 #define DEMO_GREYSCALE_IMG2_H
 
-#include "sdkconfig.h"
-
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 extern void demoGreyscaleImg2(void);
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1
 
 #endif // DEMO_GREYSCALE_IMG2_H

--- a/main/demo_greyscale_img3.c
+++ b/main/demo_greyscale_img3.c
@@ -1,14 +1,18 @@
 #include "sdkconfig.h"
 
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
+#include <string.h>
+
 #include <badge_input.h>
 #include <badge_eink_dev.h>
 #include <badge_eink_lut.h>
+#include <badge_eink_fb.h>
 #include <badge_eink.h>
 
 #include "img_hacking.h"
 
 void demoGreyscaleImg3(void) {
+  uint32_t *tmpbuf = (uint32_t *) badge_eink_fb;
+
   // curved
   const uint8_t lvl_buf[128] = {
       0,   4,   9,   13,  17,  22,  26,  30,  34,  38,  42,  45,  49,  53,  57,
@@ -26,13 +30,7 @@ void demoGreyscaleImg3(void) {
   int i;
   for (i = 0; i < 3; i++) {
     /* draw initial pattern */
-    badge_eink_set_ram_area(0, DISP_SIZE_X_B - 1, 0, DISP_SIZE_Y - 1);
-    badge_eink_set_ram_pointer(0, 0);
-    badge_eink_dev_write_command_init(0x24);
-    int c;
-    for (c = 0; c < DISP_SIZE_X_B * DISP_SIZE_Y; c++)
-      badge_eink_dev_write_byte((i & 1) ? 0xff : 0x00);
-    badge_eink_dev_write_command_end();
+    memset(tmpbuf, (i & 1) ? 0xff : 0x00, DISP_SIZE_X_B * DISP_SIZE_Y);
 
     struct badge_eink_update eink_upd = {
       .lut      = BADGE_EINK_LUT_DEFAULT,
@@ -41,7 +39,7 @@ void demoGreyscaleImg3(void) {
       .y_start  = 0,
       .y_end    = 295,
     };
-    badge_eink_update(&eink_upd);
+    badge_eink_update(tmpbuf, &eink_upd);
   }
 
   for (i = 64; i > 0; i >>= 1) {
@@ -58,13 +56,11 @@ void demoGreyscaleImg3(void) {
       int y_start = 0 + j * (DISP_SIZE_Y / p);
       int y_end = y_start + (DISP_SIZE_Y / p) - 1;
 
-      badge_eink_set_ram_area(0, DISP_SIZE_X_B - 1, 0, DISP_SIZE_Y - 1);
-      badge_eink_set_ram_pointer(0, 0);
-      badge_eink_dev_write_command_init(0x24);
       int x, y;
       const uint8_t *ptr = img_hacking;
+      uint32_t *dptr = tmpbuf;
       for (y = 0; y < DISP_SIZE_Y; y++) {
-        uint8_t res = 0;
+        uint32_t res = 0;
         for (x = 0; x < DISP_SIZE_X; x++) {
           res <<= 1;
           uint8_t pixel = *ptr++;
@@ -73,21 +69,20 @@ void demoGreyscaleImg3(void) {
             ;
           if (y >= y_start && y <= y_end && j & i)
             res++;
-          if ((x & 7) == 7)
-            badge_eink_dev_write_byte(res);
+          if ((x & 31) == 31)
+            *dptr++ = res;
         }
       }
-      badge_eink_dev_write_command_end();
 
       // LUT:
       //   Ignore old state;
       //   Do nothing when bit is not set;
       //   Make pixel whiter when bit is set;
       //   Duration is <ii> cycles.
-	  struct badge_eink_lut_entry lut[] = {
-		  { .length = ii, .voltages = 0x88, },
-		  { .length = 0 }
-	  };
+      struct badge_eink_lut_entry lut[] = {
+        { .length = ii, .voltages = 0x88, },
+        { .length = 0 }
+      };
 
       struct badge_eink_update eink_upd = {
         .lut      = BADGE_EINK_LUT_CUSTOM,
@@ -97,12 +92,10 @@ void demoGreyscaleImg3(void) {
         .y_start  = y_start,
         .y_end    = y_end + 1,
       };
-      badge_eink_update(&eink_upd);
+      badge_eink_update(tmpbuf, &eink_upd);
     }
   }
 
   // wait for random keypress
   badge_input_get_event(-1);
 }
-
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1

--- a/main/demo_greyscale_img3.h
+++ b/main/demo_greyscale_img3.h
@@ -1,10 +1,6 @@
 #ifndef DEMO_GREYSCALE_IMG3_H
 #define DEMO_GREYSCALE_IMG3_H
 
-#include "sdkconfig.h"
-
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
 extern void demoGreyscaleImg3(void);
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1
 
 #endif // DEMO_GREYSCALE_IMG3_H

--- a/main/demo_partial_update.c
+++ b/main/demo_partial_update.c
@@ -3,6 +3,7 @@
 #include <esp_event.h>
 
 #include <badge_eink.h>
+#include <badge_eink_fb.h>
 #include <badge_input.h>
 
 #include "imgv2_sha.h"
@@ -10,6 +11,8 @@
 
 void
 demoPartialUpdate(void) {
+	uint32_t *tmpbuf = (uint32_t *) badge_eink_fb;
+
 	struct badge_eink_update eink_upd = {
 		.lut      = BADGE_EINK_LUT_DEFAULT,
 //		.reg_0x3a = 26,   // 26 dummy lines per gate
@@ -26,7 +29,7 @@ demoPartialUpdate(void) {
 		badge_eink_display(imgv2_sha, DISPLAY_FLAG_NO_UPDATE);
 		eink_upd.y_start = 37 * j;
 		eink_upd.y_end   = 37 * j + 36;
-		badge_eink_update(&eink_upd);
+		badge_eink_update(NULL, &eink_upd);
 
 		vTaskDelay(1000 / portTICK_PERIOD_MS);
 	}
@@ -36,7 +39,7 @@ demoPartialUpdate(void) {
 		badge_eink_display(imgv2_nick, DISPLAY_FLAG_NO_UPDATE);
 		eink_upd.y_start = 37 * j;
 		eink_upd.y_end   = 37 * j + 36;
-		badge_eink_update(&eink_upd);
+		badge_eink_update(NULL, &eink_upd);
 
 		vTaskDelay(1000 / portTICK_PERIOD_MS);
 	}

--- a/main/main.c
+++ b/main/main.c
@@ -49,19 +49,15 @@ const struct menu_item demoMenu[] = {
 #endif // I2C_MPR121_ADDR
     {"text demo 1", &demoText1},
     {"text demo 2", &demoText2},
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
     {"greyscale 1", &demoGreyscale1},
     {"greyscale 2", &demoGreyscale2},
     {"greyscale image 1", &demoGreyscaleImg1},
     {"greyscale image 2", &demoGreyscaleImg2},
     {"greyscale image 3", &demoGreyscaleImg3},
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1
     {"greyscale image 4", &demoGreyscaleImg4},
 	{"demo sd-card image", &demo_sdcard_image},
     {"partial update test", &demoPartialUpdate},
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
     {"dot 1", &demoDot1},
-#endif // CONFIG_SHA_BADGE_EINK_GDEH029A1
     {"ADC test", &demoTestAdc},
 #ifdef PIN_NUM_LEDS
     {"LEDs demo", &demo_leds},
@@ -121,6 +117,11 @@ displayMenu(const char *menu_title, const struct menu_item *itemlist) {
 				ets_printf("Selected '%s'\n", itemlist[item_pos].title);
 				if (itemlist[item_pos].handler != NULL)
 					itemlist[item_pos].handler();
+
+				// reset screen
+				memset(badge_eink_fb, 0xff, BADGE_EINK_WIDTH * BADGE_EINK_HEIGHT / 8);
+				badge_eink_display(badge_eink_fb, DISPLAY_FLAG_LUT(BADGE_EINK_LUT_NORMAL) | DISPLAY_FLAG_FULL_UPDATE);
+
 				need_redraw = true;
 				ets_printf("Button START handled\n");
 				continue;


### PR DESCRIPTION
This makes the code a bit cleaner; we did already always write the
raw buffer to the eink just before the update.

Now all demo* code works on both displays.