### PR TITLE
Support both eink types.

### DIFF
--- a/components/badge-first-run/badge_first_run.c
+++ b/components/badge-first-run/badge_first_run.c
@@ -400,7 +400,7 @@ badge_first_run(void)
 	char line[100];
 
 	// initialize display
-	esp_err_t err = badge_eink_init();
+	esp_err_t err = badge_eink_init(BADGE_EINK_DEFAULT);
 	assert( err == ESP_OK );
 
 	err = badge_eink_fb_init();
@@ -698,6 +698,9 @@ badge_first_run(void)
 
 	nvs_handle my_handle;
 	err = nvs_open("badge", NVS_READWRITE, &my_handle);
+	ESP_ERROR_CHECK( err );
+
+	err = nvs_set_u8(my_handle, "eink.dev.type", BADGE_EINK_DEFAULT);
 	ESP_ERROR_CHECK( err );
 
 #ifdef I2C_MPR121_ADDR

--- a/components/badge/Kconfig
+++ b/components/badge/Kconfig
@@ -24,17 +24,17 @@ config SHA_BADGE_NONE
     bool "Plain ESP32"
 endchoice
 
-choice SHA_BADGE_EINK_TYPE
-    prompt "SHA Badge e-ink display type"
-    default SHA_BADGE_EINK_DEPG0290B1
+choice SHA_BADGE_EINK_DEFAULT_TYPE
+    prompt "SHA Badge e-ink default display type"
+    default SHA_BADGE_EINK_DEF_DEPG0290B1
     depends on SHA_BADGE_V1 || SHA_BADGE_V2 || SHA_BADGE_V3
     help
         The DEPG0290B1 is the cheaper alternative.
         The GDEH029A1 was the original e-ink display.
 
-config SHA_BADGE_EINK_DEPG0290B1
+config SHA_BADGE_EINK_DEF_DEPG0290B1
     bool "DEPG0290B1"
-config SHA_BADGE_EINK_GDEH029A1
+config SHA_BADGE_EINK_DEF_GDEH029A1
     bool "GDEH029A1"
 endchoice
 

--- a/components/badge/badge.c
+++ b/components/badge/badge.c
@@ -16,6 +16,7 @@
 #include "badge_leds.h"
 #include "badge_vibrator.h"
 #include "badge_sdcard.h"
+#include "badge_eink_dev.h"
 #include "badge_eink.h"
 #include "badge_nvs.h"
 
@@ -257,7 +258,9 @@ badge_init(void)
 	}
 
 	// configure eink display
-	err = badge_eink_init();
+	uint8_t eink_type = BADGE_EINK_DEFAULT;
+	badge_nvs_get_u8("badge", "eink.dev.type", &eink_type);
+	err = badge_eink_init(eink_type);
 	if (err != ESP_OK)
 	{
 		ESP_LOGE(TAG, "badge_eink_init failed: %d", err);

--- a/components/badge/badge_eink.h
+++ b/components/badge/badge_eink.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <esp_err.h>
 
+#include <badge_eink_types.h>
+
 /** the width of the eink display */
 #define BADGE_EINK_WIDTH  296
 
@@ -14,7 +16,7 @@
 /** Initialize the eink display
  * @return ESP_OK on success; any other value indicates an error
  */
-extern esp_err_t badge_eink_init(void);
+extern esp_err_t badge_eink_init(enum badge_eink_dev_t dev_type);
 
 /** badge_eink_update 'lut' settings */
 enum badge_eink_lut

--- a/components/badge/badge_eink_dev.c
+++ b/components/badge/badge_eink_dev.c
@@ -37,9 +37,11 @@
 #define VSPICLK_OUT_IDX VSPICLK_OUT_MUX_IDX
 #endif
 
-#ifdef PIN_NUM_EPD_RESET
-
 static const char *TAG = "badge_eink_dev";
+
+enum badge_eink_dev_t badge_eink_dev_type = BADGE_EINK_DEFAULT;
+
+#ifdef PIN_NUM_EPD_RESET
 
 esp_err_t
 badge_eink_dev_reset(void) {
@@ -131,7 +133,7 @@ badge_eink_dev_write_command_end(void)
 }
 
 esp_err_t
-badge_eink_dev_init(void)
+badge_eink_dev_init(enum badge_eink_dev_t dev_type)
 {
 	static bool badge_eink_dev_init_done = false;
 
@@ -139,6 +141,8 @@ badge_eink_dev_init(void)
 		return ESP_OK;
 
 	ESP_LOGD(TAG, "init called");
+
+	badge_eink_dev_type = dev_type;
 
 	esp_err_t res = badge_base_init();
 	if (res != ESP_OK)
@@ -277,7 +281,7 @@ badge_eink_dev_write_command_end(void)
 }
 
 esp_err_t
-badge_eink_dev_init(void)
+badge_eink_dev_init(enum badge_eink_dev_t dev_type)
 {
 	return ESP_OK;
 }

--- a/components/badge/badge_eink_dev.h
+++ b/components/badge/badge_eink_dev.h
@@ -6,15 +6,20 @@
 #include <stdint.h>
 #include <esp_err.h>
 
+#include <badge_eink_types.h>
+
 // low-level display, 90 degrees rotated
 #define DISP_SIZE_X 128
 #define DISP_SIZE_Y 296
 #define DISP_SIZE_X_B ((DISP_SIZE_X + 7) >> 3)
 
+extern enum badge_eink_dev_t badge_eink_dev_type;
+
 /** Initialize the SPI bus to the eink display.
  * @return ESP_OK on success; any other value indicates an error
  */
-extern esp_err_t badge_eink_dev_init(void);
+extern esp_err_t badge_eink_dev_init(enum badge_eink_dev_t dev_type);
+
 /** Send reset to the device
  * @return ESP_OK on success; any other value indicates an error
  */

--- a/components/badge/badge_eink_lut.c
+++ b/components/badge/badge_eink_lut.c
@@ -10,6 +10,7 @@
 
 #include <esp_log.h>
 
+#include "badge_eink_dev.h"
 #include "badge_eink_lut.h"
 
 static const char *TAG = "badge_eink_lut";
@@ -84,10 +85,8 @@ badge_eink_lut_conv(uint8_t voltages, enum badge_eink_lut_flags flags)
 
 
 // GDEH029A1
-#ifdef CONFIG_SHA_BADGE_EINK_GDEH029A1
-
 int
-badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags, uint8_t *lut)
+badge_eink_lut_generate_gdeh029a1(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags, uint8_t *lut)
 {
 	ESP_LOGD(TAG, "flags = %d.", flags);
 
@@ -152,10 +151,8 @@ badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink
 }
 
 // DEPG0290B01
-#elif defined( CONFIG_SHA_BADGE_EINK_DEPG0290B1 )
-
 int
-badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags, uint8_t *lut)
+badge_eink_lut_generate_depg0290b1(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags, uint8_t *lut)
 {
 	ESP_LOGD(TAG, "flags = %d.", flags);
 
@@ -222,12 +219,18 @@ badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink
 	return 70;
 }
 
-#else
-
 int
 badge_eink_lut_generate(const struct badge_eink_lut_entry *list, enum badge_eink_lut_flags flags, uint8_t *lut)
 {
+	if ( badge_eink_dev_type == BADGE_EINK_GDEH029A1 )
+	{
+		return badge_eink_lut_generate_gdeh029a1(list, flags, lut);
+	}
+
+	if ( badge_eink_dev_type == BADGE_EINK_DEPG0290B1 )
+	{
+		return badge_eink_lut_generate_depg0290b1(list, flags, lut);
+	}
+
 	return 0;
 }
-
-#endif

--- a/components/badge/badge_eink_types.h
+++ b/components/badge/badge_eink_types.h
@@ -1,0 +1,25 @@
+/** @file badge_eink_types.h */
+#ifndef BADGE_EINK_TYPES_H
+#define BADGE_EINK_TYPES_H
+
+#include <sdkconfig.h>
+
+/**
+ * Badge eink types.
+ */
+/* NOTE: This value is used in nvs. Do not change order or remove elements. */
+enum badge_eink_dev_t {
+	BADGE_EINK_NONE,
+	BADGE_EINK_GDEH029A1,
+	BADGE_EINK_DEPG0290B1,
+};
+
+#if defined(CONFIG_SHA_BADGE_EINK_DEF_DEPG0290B1)
+ #define BADGE_EINK_DEFAULT BADGE_EINK_DEPG0290B1
+#elif defined(CONFIG_SHA_BADGE_EINK_DEF_GDEH029A1)
+ #define BADGE_EINK_DEFAULT BADGE_EINK_GDEH029A1
+#else
+ #define BADGE_EINK_DEFAULT BADGE_EINK_NONE
+#endif
+
+#endif // BADGE_EINK_TYPES_H

--- a/components/ugfx-glue/board_framebuffer.h
+++ b/components/ugfx-glue/board_framebuffer.h
@@ -34,7 +34,7 @@ uint8_t target_lut;
 #ifdef GDISP_DRIVER_VMT
 
 	static void board_init(GDisplay *g, fbInfo *fbi) {
-		esp_err_t err = badge_eink_init();
+		esp_err_t err = badge_eink_init(BADGE_EINK_DEFAULT);
 		assert( err == ESP_OK );
 
 		err = badge_eink_fb_init();


### PR DESCRIPTION
There was a request to support OTA updates on custom-built badges with the GDEH display.

With this patch and one nvs setting, we support this.