### PR TITLE
workaround for the leds-disable.

### DIFF
--- a/components/badge/badge_leds.c
+++ b/components/badge/badge_leds.c
@@ -61,8 +61,6 @@ badge_leds_enable(void)
 	return ESP_OK;
 }
 
-extern esp_err_t badge_eink_dev_setup_spi(void);
-
 esp_err_t
 badge_leds_disable(void)
 {

--- a/components/badge/badge_leds.c
+++ b/components/badge/badge_leds.c
@@ -77,7 +77,7 @@ badge_leds_disable(void)
 	// FIXME:
 	//   Freeing the HSPI seems to (de)configure the VSPI as well..
 	//   See issue #70 on github.
-	//   Current workaround is an ugly hack in the esp-idf tree.
+	//   edit: fixed upstream.
 	res = spi_bus_free(HSPI_HOST);
 	if (res != ESP_OK)
 		return res;

--- a/components/badge/badge_leds.c
+++ b/components/badge/badge_leds.c
@@ -61,6 +61,8 @@ badge_leds_enable(void)
 	return ESP_OK;
 }
 
+extern esp_err_t badge_eink_dev_setup_spi(void);
+
 esp_err_t
 badge_leds_disable(void)
 {
@@ -74,10 +76,13 @@ badge_leds_disable(void)
 
 	badge_leds_spi = NULL;
 
-//	FIXME: freeing the HSPI seems to (de)configure the VSPI as well..
-//	res = spi_bus_free(HSPI_HOST);
-//	if (res != ESP_OK)
-//		return res;
+	// FIXME:
+	//   Freeing the HSPI seems to (de)configure the VSPI as well..
+	//   See issue #70 on github.
+	//   Current workaround is an ugly hack in the esp-idf tree.
+	res = spi_bus_free(HSPI_HOST);
+	if (res != ESP_OK)
+		return res;
 
 	// configure PIN_NUM_LEDS as high-impedance
 	gpio_config_t io_conf = {


### PR DESCRIPTION
With this patch, the leds enable and disable things work.

To test this:

    badge.leds_send_data(b'\x01\x00\x00\x00', 4)
    // green light should go on
    badge.leds_disable()
    // green light should go off
    badge.eink_png(0, 0, '/media/hacking.png')
    ugfx.flush()
    // hacking image (black/white) should appear
    badge.leds_send_data(b'\x01\x00\x00\x00', 4)
    // green light should go on