### PR TITLE
Refactoring badge_eink greyscale implementation

### DIFF
--- a/components/badge-first-run/badge_first_run.c
+++ b/components/badge-first-run/badge_first_run.c
@@ -737,7 +737,7 @@ badge_first_run(void)
 	load_png(0,0, "/media/hacking.png");
 	load_png(2,2, "/media/badge_version.png");
 	load_png(0,0, "/media/badge_type.png");
-	badge_eink_display(badge_eink_fb, DISPLAY_FLAG_GREYSCALE);
+	badge_eink_display_greyscale(badge_eink_fb, DISPLAY_FLAG_8BITPIXEL, 16);
 
 	while (1)
 	{

--- a/components/badge/badge_eink.h
+++ b/components/badge/badge_eink.h
@@ -77,7 +77,9 @@ extern void badge_eink_display_one_layer(const uint8_t *img, int flags);
  * - slow/full update
  * - greyscale update
  */
-extern void badge_eink_display(const uint8_t *img, int mode);
+extern void badge_eink_display(const uint8_t *img, int flags);
+
+extern void badge_eink_display_greyscale(const uint8_t *img, int flags, int layers);
 
 
 /* And some more low-level methods; only use them if you know what you're doing. :-) */

--- a/components/badge/badge_eink.h
+++ b/components/badge/badge_eink.h
@@ -56,7 +56,7 @@ extern void badge_eink_update(const uint32_t *buf, const struct badge_eink_updat
 
 /* badge_eink_display 'mode' settings */
 // bitmapped flags:
-#define DISPLAY_FLAG_GREYSCALE  1
+#define DISPLAY_FLAG_8BITPIXEL  1
 #define DISPLAY_FLAG_ROTATE_180 2
 #define DISPLAY_FLAG_NO_UPDATE  4
 #define DISPLAY_FLAG_FULL_UPDATE 8
@@ -65,7 +65,6 @@ extern void badge_eink_update(const uint32_t *buf, const struct badge_eink_updat
 #define DISPLAY_FLAG_LUT_SIZE   4
 #define DISPLAY_FLAG_LUT(x) ((1+(x)) << DISPLAY_FLAG_LUT_BIT)
 
-extern void badge_eink_display_one_layer(const uint8_t *img, int flags);
 /*
  * display image on badge
  *
@@ -79,14 +78,10 @@ extern void badge_eink_display_one_layer(const uint8_t *img, int flags);
  */
 extern void badge_eink_display(const uint8_t *img, int flags);
 
+/*
+ * display image on badge with greyscale hack
+ */
 extern void badge_eink_display_greyscale(const uint8_t *img, int flags, int layers);
-
-
-/* And some more low-level methods; only use them if you know what you're doing. :-) */
-
-extern void badge_eink_set_ram_area(uint8_t x_start, uint8_t x_end,
-		uint16_t y_start, uint16_t y_end);
-extern void badge_eink_set_ram_pointer(uint8_t x_addr, uint16_t y_addr);
 
 extern void badge_eink_deep_sleep(void);
 extern void badge_eink_wakeup(void);

--- a/components/ugfx-glue/board_framebuffer.h
+++ b/components/ugfx-glue/board_framebuffer.h
@@ -55,15 +55,16 @@ uint8_t target_lut;
 
 			if (target_lut >= 0xf0)
 			{
-				badge_eink_display(badge_eink_fb, DISPLAY_FLAG_GREYSCALE);
+				// 0xf0 was used in some examples. support it for now..
+				badge_eink_display_greyscale(badge_eink_fb, DISPLAY_FLAG_8BITPIXEL, target_lut > 0xf0 ? target_lut - 0xf0 : 16);
 			}
 			else if (target_lut < 0 || target_lut > BADGE_EINK_LUT_MAX)
 			{
-				badge_eink_display_one_layer(badge_eink_fb, DISPLAY_FLAG_GREYSCALE);
+				badge_eink_display(badge_eink_fb, DISPLAY_FLAG_8BITPIXEL);
 			}
 			else
 			{
-				badge_eink_display_one_layer(badge_eink_fb, DISPLAY_FLAG_LUT(target_lut) | DISPLAY_FLAG_GREYSCALE);
+				badge_eink_display(badge_eink_fb, DISPLAY_FLAG_LUT(target_lut) | DISPLAY_FLAG_8BITPIXEL);
 			}
 		}
 	#endif

--- a/main/demo_greyscale_img4.c
+++ b/main/demo_greyscale_img4.c
@@ -8,7 +8,7 @@
 void
 demoGreyscaleImg4(void)
 {
-	badge_eink_display(imgv2_hacking, DISPLAY_FLAG_GREYSCALE);
+	badge_eink_display_greyscale(imgv2_hacking, DISPLAY_FLAG_8BITPIXEL, 16);
 
 	// wait for random keypress
 	badge_input_get_event(-1);

--- a/main/demo_sdcard_image.c
+++ b/main/demo_sdcard_image.c
@@ -86,7 +86,7 @@ demo_sdcard_image(void)
 		return;
 	}
 
-	badge_eink_display(badge_eink_fb, DISPLAY_FLAG_GREYSCALE);
+	badge_eink_display_greyscale(badge_eink_fb, DISPLAY_FLAG_8BITPIXEL, 16);
 
 	// wait for random keypress
 	badge_input_get_event(-1);


### PR DESCRIPTION
BADGE_EINK_GREYSCALE renamed to BADGE_EINK_8BITPIXEL.
(it was already used as 8-bit-pixel indicator)

moved the greyscale hack to badge_eink_display_greyscale. Added layers attribute to specify the number of layers to display.