### PR TITLE
Allow C++ compilers to include the badge headers.

### DIFF
--- a/components/badge/badge.h
+++ b/components/badge/badge.h
@@ -2,9 +2,13 @@
 #ifndef BADGE_H
 #define BADGE_H
 
+__BEGIN_DECLS
+
 /**
  * Initialize all badge drivers.
  */
 extern void badge_init(void);
+
+__END_DECLS
 
 #endif // BADGE_H

--- a/components/badge/badge_base.h
+++ b/components/badge/badge_base.h
@@ -4,10 +4,14 @@
 
 #include <esp_err.h>
 
+__BEGIN_DECLS
+
 /**
  * Initialize badge base driver.
  * @return ESP_OK on success; any other value indicates an error
  */
 extern esp_err_t badge_base_init(void);
+
+__END_DECLS
 
 #endif // BADGE_BASE_H

--- a/components/badge/badge_cpt112s.h
+++ b/components/badge/badge_cpt112s.h
@@ -7,6 +7,8 @@
 /** callback handler for cpt112s events */
 typedef void (*badge_cpt112s_event_t)(int event);
 
+__BEGIN_DECLS
+
 /** initialize the badge cpt112s controller
  * @return ESP_OK on success; any other value indicates an error
  */
@@ -14,5 +16,7 @@ extern esp_err_t badge_cpt112s_init(void);
 
 /** set the cpt112s-event callback method */
 extern void badge_cpt112s_set_event_handler(badge_cpt112s_event_t handler);
+
+__END_DECLS
 
 #endif // BADGE_CPT112S_H

--- a/components/badge/badge_eink.h
+++ b/components/badge/badge_eink.h
@@ -11,6 +11,9 @@
 #define BADGE_EINK_WIDTH  296
 
 /** the height of the eink display */
+
+__BEGIN_DECLS
+
 #define BADGE_EINK_HEIGHT 128
 
 /** Initialize the eink display
@@ -89,4 +92,5 @@ extern void badge_eink_set_ram_pointer(uint8_t x_addr, uint16_t y_addr);
 extern void badge_eink_deep_sleep(void);
 extern void badge_eink_wakeup(void);
 
+__END_DECLS
 #endif // BADGE_EINK_H

--- a/components/badge/badge_eink_dev.h
+++ b/components/badge/badge_eink_dev.h
@@ -15,6 +15,8 @@
 
 extern enum badge_eink_dev_t badge_eink_dev_type;
 
+__BEGIN_DECLS
+
 /** Initialize the SPI bus to the eink display.
  * @return ESP_OK on success; any other value indicates an error
  */
@@ -96,5 +98,7 @@ static inline void badge_eink_dev_write_command_stream_u32(uint8_t command, cons
 	}
 	badge_eink_dev_write_command_end();
 }
+
+__END_DECLS
 
 #endif // BADGE_EINK_DEV_H

--- a/components/badge/badge_eink_fb.h
+++ b/components/badge/badge_eink_fb.h
@@ -7,6 +7,8 @@
 
 #include "badge_eink.h"
 
+__BEGIN_DECLS
+
 #define BADGE_EINK_FB_LEN (BADGE_EINK_WIDTH * BADGE_EINK_HEIGHT)
 
 /** A one byte per pixel frame-buffer */
@@ -17,5 +19,7 @@ extern uint8_t *badge_eink_fb;
  * @return ESP_OK on success; any other value indicates an error
  */
 extern esp_err_t badge_eink_fb_init(void);
+
+__END_DECLS
 
 #endif // BADGE_EINK_FB_H

--- a/components/badge/badge_eink_lut.h
+++ b/components/badge/badge_eink_lut.h
@@ -31,6 +31,8 @@ enum badge_eink_lut_flags {
 	LUT_FLAG_BLACK    = 8, // black only
 };
 
+__BEGIN_DECLS
+
 /**
  * Generate LUT data for specific eink display.
  *
@@ -46,5 +48,7 @@ extern const struct badge_eink_lut_entry badge_eink_lut_full[];
 extern const struct badge_eink_lut_entry badge_eink_lut_normal[];
 extern const struct badge_eink_lut_entry badge_eink_lut_faster[];
 extern const struct badge_eink_lut_entry badge_eink_lut_fastest[];
+
+__END_DECLS
 
 #endif // BADGE_EINK_LUT_H

--- a/components/badge/badge_fxl6408.h
+++ b/components/badge/badge_fxl6408.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <esp_err.h>
 
+__BEGIN_DECLS
+
 /** port-expander interrupt handler */
 typedef void (*badge_fxl6408_intr_t)(void*);
 
@@ -34,5 +36,7 @@ extern void badge_fxl6408_set_interrupt_handler(uint8_t pin, badge_fxl6408_intr_
 extern int badge_fxl6408_get_input(void);
 /** configure port-expander gpio port - get interrupt status */
 extern int badge_fxl6408_get_interrupt_status(void);
+
+__END_DECLS
 
 #endif // BADGE_FXL6408_H

--- a/components/badge/badge_gpiobutton.h
+++ b/components/badge/badge_gpiobutton.h
@@ -5,10 +5,13 @@
 #include <stdint.h>
 #include <esp_err.h>
 
+__BEGIN_DECLS
+
 /** configure gpio pin as button
  * @return ESP_OK on success; any other value indicates an error
  */
 extern esp_err_t badge_gpiobutton_add(int gpio_num, uint32_t button_id);
 
-#endif // BADGE_GPIOBUTTON_H
+__END_DECLS
 
+#endif // BADGE_GPIOBUTTON_H

--- a/components/badge/badge_i2c.h
+++ b/components/badge/badge_i2c.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <esp_err.h>
 
+__BEGIN_DECLS
+
 /** initialize i2c bus
  * @return ESP_OK on success; any other value indicates an error
  */
@@ -24,5 +26,7 @@ extern esp_err_t badge_i2c_write_reg(uint8_t addr, uint8_t reg, uint8_t value);
  * @return ESP_OK on success; any other value indicates an error
  */
 extern esp_err_t badge_i2c_read_event(uint8_t addr, uint8_t *buf);
+
+__END_DECLS
 
 #endif // BADGE_I2C_H

--- a/components/badge/badge_input.h
+++ b/components/badge/badge_input.h
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include <esp_err.h>
 
+__BEGIN_DECLS
+
 /** initialize badge input
  * @return ESP_OK on success; any other value indicates an error
  */
@@ -35,5 +37,7 @@ extern uint32_t badge_input_button_state;
 
 /** callback method to get notifies on events. */
 extern void (*badge_input_notify)(void);
+
+__END_DECLS
 
 #endif // BADGE_INPUT_H

--- a/components/badge/badge_mpr121.h
+++ b/components/badge/badge_mpr121.h
@@ -6,6 +6,8 @@
 #include <stdint.h>
 #include <esp_err.h>
 
+__BEGIN_DECLS
+
 /** interrupt handler type */
 typedef void (*badge_mpr121_intr_t)(void*, bool);
 
@@ -101,5 +103,7 @@ extern int badge_mpr121_get_gpio_level(int pin);
  * @return 0 on succes; -1 on error
  */
 extern int badge_mpr121_set_gpio_level(int pin, int value);
+
+__END_DECLS
 
 #endif // BADGE_MPR121_H

--- a/components/badge/badge_nvs.h
+++ b/components/badge/badge_nvs.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <esp_err.h>
 
+__BEGIN_DECLS
+
 /**
  * Initialize the nvs driver.
  * @return ESP_OK on success; any other value indicates an error
@@ -58,5 +60,7 @@ extern esp_err_t badge_nvs_get_str(const char* namespace, const char* key, char 
  * @return ESP_OK on success; any other value indicates an error
  */
 extern esp_err_t badge_nvs_set_str(const char* namespace, const char* key, const char *value);
+
+__END_DECLS
 
 #endif // BADGE_NVS_H

--- a/components/badge/badge_power.h
+++ b/components/badge/badge_power.h
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 #include <esp_err.h>
 
+__BEGIN_DECLS
+
 /**
  * initializes the battery and usb power sensing
  * @return ESP_OK on success; any other value indicates an error
@@ -63,5 +65,7 @@ extern esp_err_t badge_power_sdcard_enable(void);
  *   the power will stay on.
  */
 extern esp_err_t badge_power_sdcard_disable(void);
+
+__END_DECLS
 
 #endif // BADGE_POWER_H

--- a/components/badge/badge_sdcard.h
+++ b/components/badge/badge_sdcard.h
@@ -5,6 +5,8 @@
 #include <stdbool.h>
 #include <esp_err.h>
 
+__BEGIN_DECLS
+
 /** initialize the sdcard inserted sensor
  * @return ESP_OK on success; any other value indicates an error
  */
@@ -12,5 +14,7 @@ extern esp_err_t badge_sdcard_init(void);
 
 /** report if an sdcard is inserted */
 extern bool badge_sdcard_detected(void);
+
+__END_DECLS
 
 #endif // BADGE_SDCARD_H

--- a/components/badge/badge_vibrator.h
+++ b/components/badge/badge_vibrator.h
@@ -5,6 +5,8 @@
 #include <stdint.h>
 #include <esp_err.h>
 
+__BEGIN_DECLS
+
 /**
  * Initialize vibrator driver. (GPIO ports)
  * @return ESP_OK on success; any other value indicates an error
@@ -21,5 +23,7 @@ extern esp_err_t badge_vibrator_init(void);
  *   // vibrator will be on for 200ms. Then off for 200ms. Then on for 400ms.
  */
 extern void badge_vibrator_activate(uint32_t pattern);
+
+__END_DECLS
 
 #endif // BADGE_VIBRATOR_H


### PR DESCRIPTION
Wraps all of the headers with `__BEGIN_DECLS` and `__END_DECLS` so that C++ compilers like the Arduino framework can include the badge component headers.