### PR TITLE
add haptic feedback to buttons

### DIFF
--- a/components/badge/badge_input.c
+++ b/components/badge/badge_input.c
@@ -8,6 +8,7 @@
 #include <esp_log.h>
 
 #include "badge_input.h"
+#include "badge_vibrator.h"
 
 static const char *TAG = "badge_input";
 
@@ -76,6 +77,7 @@ badge_input_add_event(uint32_t button_id, bool pressed, bool in_isr)
 				ets_printf("badge_input: input queue full.\n");
 			}
 		}
+		badge_vibrator_buzz(70000);
 	}
 	else
 	{

--- a/components/badge/badge_vibrator.c
+++ b/components/badge/badge_vibrator.c
@@ -56,6 +56,14 @@ badge_vibrator_activate(uint32_t pattern)
 	badge_vibrator_off();
 }
 
+void
+badge_vibrator_buzz(uint32_t length)
+{
+	badge_vibrator_on();
+	ets_delay_us(length);
+	badge_vibrator_off();
+}
+
 esp_err_t
 badge_vibrator_init(void)
 {

--- a/components/badge/badge_vibrator.h
+++ b/components/badge/badge_vibrator.h
@@ -24,6 +24,16 @@ extern esp_err_t badge_vibrator_init(void);
  */
 extern void badge_vibrator_activate(uint32_t pattern);
 
+/**
+ * Activate the vibrator for the specified number of microseconds.
+ *
+ * Code example:
+ *
+ *   badge_vibrator_activate(200000);
+ *   // vibrator will be on for 200ms.
+ */
+extern void badge_vibrator_buzz(uint32_t length);
+
 __END_DECLS
 
 #endif // BADGE_VIBRATOR_H


### PR DESCRIPTION
This patch adds haptic feedback to buttons by turning on the vibration motor for 70ms after each button press.
This is busy sleep (as a PoC), but even with the added lag limited user acceptance tests have been good so far.