### PR TITLE
Update of the spi driver so the Frimware works with the latest esp-idf 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ makeenv
 custom_env.sh
 doxygen/
 .DS_Store
+
+# Eclipse configuration
+.settings
+.project
+.cproject

--- a/components/badge-first-run/badge_first_run.c
+++ b/components/badge-first-run/badge_first_run.c
@@ -594,7 +594,7 @@ badge_first_run(void)
 	cfg.nvs_enable = 0;
 	int res = esp_wifi_init(&cfg);
 	if (res == ESP_OK) {
-		res = esp_wifi_set_country(WIFI_COUNTRY_EU);
+		res = esp_wifi_set_country(WIFI_COUNTRY_POLICY_AUTO);
 	}
 	if (res == ESP_OK) {
 		res = esp_wifi_set_mode(WIFI_MODE_STA);

--- a/components/badge/badge_eink_dev.h
+++ b/components/badge/badge_eink_dev.h
@@ -57,44 +57,30 @@ extern void badge_eink_dev_write_byte(uint8_t data);
  */
 extern void badge_eink_dev_write_command(uint8_t command);
 
-/** write an spi command byte to the display
- * @param command the byte to write
- * @note send data-bytes wit badge_eink_dev_write_byte() and close the
- *   command with badge_eink_dev_write_command_end()
- */
-extern void badge_eink_dev_write_command_init(uint8_t command);
-
-/** close spi command
- */
-extern void badge_eink_dev_write_command_end(void);
-
 /** helper method: write command with 1 parameter */
 static inline void badge_eink_dev_write_command_p1(uint8_t command, uint8_t para1)
 {
-	badge_eink_dev_write_command_init(command);
+	badge_eink_dev_write_command(command);
 	badge_eink_dev_write_byte(para1);
-	badge_eink_dev_write_command_end();
 }
 
 /** helper method: write command with 2 parameters */
 static inline void badge_eink_dev_write_command_p2(uint8_t command, uint8_t para1,
                                       uint8_t para2)
 {
-	badge_eink_dev_write_command_init(command);
+	badge_eink_dev_write_command(command);
 	badge_eink_dev_write_byte(para1);
 	badge_eink_dev_write_byte(para2);
-	badge_eink_dev_write_command_end();
 }
 
 /** helper method: write command with 3 parameters */
 static inline void badge_eink_dev_write_command_p3(uint8_t command, uint8_t para1,
                                       uint8_t para2, uint8_t para3)
 {
-	badge_eink_dev_write_command_init(command);
+	badge_eink_dev_write_command(command);
 	badge_eink_dev_write_byte(para1);
 	badge_eink_dev_write_byte(para2);
 	badge_eink_dev_write_byte(para3);
-	badge_eink_dev_write_command_end();
 }
 
 /** helper method: write command with 4 parameters */
@@ -102,24 +88,16 @@ static inline void badge_eink_dev_write_command_p4(uint8_t command, uint8_t para
                                       uint8_t para2, uint8_t para3,
                                       uint8_t para4)
 {
-	badge_eink_dev_write_command_init(command);
+	badge_eink_dev_write_command(command);
 	badge_eink_dev_write_byte(para1);
 	badge_eink_dev_write_byte(para2);
 	badge_eink_dev_write_byte(para3);
 	badge_eink_dev_write_byte(para4);
-	badge_eink_dev_write_command_end();
 }
 
-/** helper method: write command with `datalen` data bytes */
-static inline void badge_eink_dev_write_command_stream(uint8_t command, const uint8_t *data,
-                                         unsigned int datalen)
-{
-	badge_eink_dev_write_command_init(command);
-	while (datalen-- > 0) {
-		badge_eink_dev_write_byte(*(data++));
-	}
-	badge_eink_dev_write_command_end();
-}
+/** write command with `datalen` data bytes */
+void badge_eink_dev_write_command_stream(uint8_t command, const uint8_t *data,
+                                         unsigned int datalen);
 
 /** helper method: write 4 data bytes */
 static inline void badge_eink_dev_write_byte_u32(uint32_t data)
@@ -134,11 +112,10 @@ static inline void badge_eink_dev_write_byte_u32(uint32_t data)
 static inline void badge_eink_dev_write_command_stream_u32(uint8_t command, const uint32_t *data,
                                          unsigned int datalen)
 {
-	badge_eink_dev_write_command_init(command);
-	while (datalen-- > 0) {
-		badge_eink_dev_write_byte_u32(*(data++));
-	}
-	badge_eink_dev_write_command_end();
+    badge_eink_dev_write_command(command);
+    while (datalen-- > 0) {
+        badge_eink_dev_write_byte_u32(*(data++));
+    }
 }
 
 __END_DECLS

--- a/components/badge/badge_power.c
+++ b/components/badge/badge_power.c
@@ -24,7 +24,7 @@ int
 badge_battery_volt_sense(void)
 {
 #ifdef ADC1_CHAN_VBAT_SENSE
-	int val = adc1_get_voltage(ADC1_CHAN_VBAT_SENSE);
+	int val = adc1_get_raw(ADC1_CHAN_VBAT_SENSE);
 	if (val == -1)
 		return -1;
 
@@ -38,7 +38,7 @@ int
 badge_usb_volt_sense(void)
 {
 #ifdef ADC1_CHAN_VUSB_SENSE
-	int val = adc1_get_voltage(ADC1_CHAN_VUSB_SENSE);
+	int val = adc1_get_raw(ADC1_CHAN_VUSB_SENSE);
 	if (val == -1)
 		return -1;
 

--- a/main/demo_test_adc.c
+++ b/main/demo_test_adc.c
@@ -38,7 +38,7 @@ demoTestAdc(void) {
 			char text[TEXTLEN];
 			int val;
 			if (adc_mask & (1 << channel))
-				val = adc1_get_voltage(channel);
+				val = adc1_get_raw(channel);
 			else
 				val = -1;
 			snprintf(text, TEXTLEN, "ADC channel %d: %d", channel, val);


### PR DESCRIPTION
### Ref: https://github.com/SHA2017-badge/Firmware/issues/213

### Tested with:
- https://github.com/espressif/esp-idf/commit/f8bda324ecde58214aaa00ab5e0da5eea9942aaf

### To Do
- Update the version of the esp-idf submodule  of the 'Firmware' repository to https://github.com/espressif/esp-idf/commit/f8bda324ecde58214aaa00ab5e0da5eea9942aaf

### Possible Improvements
- Change `badge_eink_dev_write_command_stream_u32` to really stream the data as `badge_eink_dev_write_command_stream` does
- resolve compilation warnings on deprecated functions, unused variables, etc.