### PR TITLE
Fix compiler warnings.

### DIFF
--- a/components/badge/badge_eink_dev.c
+++ b/components/badge/badge_eink_dev.c
@@ -87,7 +87,9 @@ badge_eink_dev_busy_wait(void)
 void
 badge_eink_dev_intr_handler(void *arg)
 { /* in interrupt handler */
+#if defined(CONFIG_SHA_BADGE_EINK_DEBUG) || defined(PIN_NUM_LED)
 	int gpio_state = gpio_get_level(PIN_NUM_EPD_BUSY);
+#endif
 
 #ifdef CONFIG_SHA_BADGE_EINK_DEBUG
 	static int gpio_last_state = -1;

--- a/components/badge/badge_input.c
+++ b/components/badge/badge_input.c
@@ -36,6 +36,7 @@ badge_input_init(void)
 	return ESP_OK;
 }
 
+#ifdef CONFIG_SHA_BADGE_INPUT_DEBUG
 static const char *badge_input_button_name[11] = {
 	"(null)",
 	"UP",
@@ -49,6 +50,7 @@ static const char *badge_input_button_name[11] = {
 	"START",
 	"FLASH",
 };
+#endif // CONFIG_SHA_BADGE_INPUT_DEBUG
 
 void
 badge_input_add_event(uint32_t button_id, bool pressed, bool in_isr)

--- a/components/badge/badge_power.c
+++ b/components/badge/badge_power.c
@@ -24,7 +24,7 @@ int
 badge_battery_volt_sense(void)
 {
 #ifdef ADC1_CHAN_VBAT_SENSE
-	int val = adc1_get_voltage(ADC1_CHAN_VBAT_SENSE);
+	int val = adc1_get_raw(ADC1_CHAN_VBAT_SENSE);
 	if (val == -1)
 		return -1;
 
@@ -38,7 +38,7 @@ int
 badge_usb_volt_sense(void)
 {
 #ifdef ADC1_CHAN_VUSB_SENSE
-	int val = adc1_get_voltage(ADC1_CHAN_VUSB_SENSE);
+	int val = adc1_get_raw(ADC1_CHAN_VUSB_SENSE);
 	if (val == -1)
 		return -1;
 

--- a/main/demo_test_adc.c
+++ b/main/demo_test_adc.c
@@ -38,7 +38,7 @@ demoTestAdc(void) {
 			char text[TEXTLEN];
 			int val;
 			if (adc_mask & (1 << channel))
-				val = adc1_get_voltage(channel);
+				val = adc1_get_raw(channel);
 			else
 				val = -1;
 			snprintf(text, TEXTLEN, "ADC channel %d: %d", channel, val);


### PR DESCRIPTION
- badge_eink_dev: unused variable gpio_state.
- badge_input: unused variable badge_input_button_name.
- badge_power/demo_test_adc: adc1_get_voltage() is deprecated;
    switch to adc1_get_raw()